### PR TITLE
Bugfix/ignore undefined page in job agg chart

### DIFF
--- a/grails-app/services/de/iteratec/osm/barchart/BarchartAggregationService.groovy
+++ b/grails-app/services/de/iteratec/osm/barchart/BarchartAggregationService.groovy
@@ -60,7 +60,12 @@ class BarchartAggregationService {
                 .withJobResultDateBetween(from, to)
                 .withSelectedMeasurands(selectedMeasurands)
                 .withJobGroupIn(jobGroups)
-                .withPageIn(pages)
+
+        if (pages){
+            queryBuilder = queryBuilder.withPageIn(pages)
+        } else {
+            queryBuilder = queryBuilder.withoutPageIn([Page.findByName(Page.UNDEFINED)])
+        }
 
         List<EventResultProjection> eventResultProjections = []
         switch(selectedAggregationValue) {

--- a/src/integration-test/groovy/de/iteratec/osm/result/dao/EventResultQueryBuilderAverageIntegrationSpec.groovy
+++ b/src/integration-test/groovy/de/iteratec/osm/result/dao/EventResultQueryBuilderAverageIntegrationSpec.groovy
@@ -255,7 +255,7 @@ class EventResultQueryBuilderAverageIntegrationSpec extends NonTransactionalInte
         def result = new EventResultQueryBuilder(0, 1000)
                 .withJobGroupIdsIn([jobGroup1.id])
                 .withSelectedMeasurands([selectedMeasurand])
-                .withoutPageIdsIn([page3.id])
+                .withoutPageIn([page3])
                 .getAverageData()
 
         then: "the result with excluded page is not included in average"

--- a/src/integration-test/groovy/de/iteratec/osm/result/dao/EventResultQueryBuilderAverageIntegrationSpec.groovy
+++ b/src/integration-test/groovy/de/iteratec/osm/result/dao/EventResultQueryBuilderAverageIntegrationSpec.groovy
@@ -222,6 +222,50 @@ class EventResultQueryBuilderAverageIntegrationSpec extends NonTransactionalInte
         }
     }
 
+    void "excluding pages in measurand average calculation for jobGroup"() {
+        given: "two EventResults with valid and some with excluded page"
+        page1 = Page.build()
+        page2 = Page.build()
+        page3 = Page.build()
+        jobGroup1 = JobGroup.build()
+
+        EventResult.build(
+                page: page1,
+                jobGroup: jobGroup1,
+                fullyLoadedTimeInMillisecs: 100,
+                medianValue: true,
+        )
+        EventResult.build(
+                page: page2,
+                jobGroup: jobGroup1,
+                fullyLoadedTimeInMillisecs: 200,
+                medianValue: true,
+        )
+        2.times {
+            EventResult.build(
+                    page: page3,
+                    jobGroup: jobGroup1,
+                    fullyLoadedTimeInMillisecs: 500,
+                    medianValue: true,
+            )
+        }
+
+        when: "the builder is configured for measurand and jobGroup and excludes a page"
+        SelectedMeasurand selectedMeasurand = new SelectedMeasurand("FULLY_LOADED_TIME", CachedView.UNCACHED)
+        def result = new EventResultQueryBuilder(0, 1000)
+                .withJobGroupIdsIn([jobGroup1.id])
+                .withSelectedMeasurands([selectedMeasurand])
+                .withoutPageIdsIn([page3.id])
+                .getAverageData()
+
+        then: "the result with excluded page is not included in average"
+        result.size() == 1
+        result.every {
+            it.fullyLoadedTimeInMillisecs == (100+200) / 2 &&
+                    it.jobGroupId == jobGroup1.id
+        }
+    }
+
     void "check average for userTimings with jobGroup"() {
         given: "three matching and two other Eventresults"
         page1 = Page.build()
@@ -279,6 +323,57 @@ class EventResultQueryBuilderAverageIntegrationSpec extends NonTransactionalInte
         }
     }
 
+    void "excluding pages in userTiming average calculation for jobGroup"() {
+        given: "two EventResults with valid and some with excluded page"
+        page1 = Page.build()
+        page2 = Page.build()
+        page3 = Page.build()
+        jobGroup1 = JobGroup.build()
+
+        EventResult.build(
+                page: page1,
+                jobGroup: jobGroup1,
+                fullyLoadedTimeInMillisecs: 500,
+                medianValue: true,
+                userTimings: [UserTiming.build(name: "mark1", duration: new Double(100), type: UserTimingType.MEASURE)],
+                flush: true
+        )
+        EventResult.build(
+                page: page2,
+                jobGroup: jobGroup1,
+                fullyLoadedTimeInMillisecs: 500,
+                medianValue: true,
+                userTimings: [UserTiming.build(name: "mark1", duration: new Double(200), type: UserTimingType.MEASURE)],
+                flush: true
+        )
+
+        2.times {
+            EventResult.build(
+                    page: page3,
+                    jobGroup: jobGroup1,
+                    fullyLoadedTimeInMillisecs: 500,
+                    medianValue: true,
+                    userTimings: [UserTiming.build(name: "mark1", duration: new Double(800), type: UserTimingType.MEASURE)],
+                    flush: true
+            )
+        }
+
+        when: "the builder is configured for measurand and jobGroup and excludes a page"
+        SelectedMeasurand selectedMeasurand = new SelectedMeasurand("_UTME_mark1", CachedView.UNCACHED)
+        def result = new EventResultQueryBuilder(0, 1000)
+                .withJobGroupIdsIn([jobGroup1.id])
+                .withoutPageIn([page3])
+                .withSelectedMeasurands([selectedMeasurand])
+                .getAverageData()
+
+        then: "the result with excluded page is not included in average"
+        result.size() == 1
+        result.every {
+            it.mark1 == (100 + 200) / 2 &&
+                    it.jobGroupId == jobGroup1.id
+        }
+    }
+
     void "check average for measurands and userTimings with jobGroup"() {
         given: "three matching and two other Eventresults"
         page1 = Page.build()
@@ -332,6 +427,58 @@ class EventResultQueryBuilderAverageIntegrationSpec extends NonTransactionalInte
         result.every {
             it.mark1 == 300 &&
                     it.fullyLoadedTimeInMillisecs == 300 &&
+                    it.jobGroupId == jobGroup1.id
+        }
+    }
+
+    void "excluding pages in average calculation for jobGroup"() {
+        given: "two EventResults with valid and some with excluded page"
+        page1 = Page.build()
+        page2 = Page.build()
+        page3 = Page.build()
+        jobGroup1 = JobGroup.build()
+
+        EventResult.build(
+                page: page1,
+                jobGroup: jobGroup1,
+                fullyLoadedTimeInMillisecs: 100,
+                medianValue: true,
+                userTimings: [UserTiming.build(name: "mark1", duration: new Double(100), type: UserTimingType.MEASURE)],
+                flush: true
+        )
+        EventResult.build(
+                page: page2,
+                jobGroup: jobGroup1,
+                fullyLoadedTimeInMillisecs: 200,
+                medianValue: true,
+                userTimings: [UserTiming.build(name: "mark1", duration: new Double(200), type: UserTimingType.MEASURE)],
+                flush: true
+        )
+        2.times {
+            EventResult.build(
+                    page: page3,
+                    jobGroup: jobGroup1,
+                    fullyLoadedTimeInMillisecs: 600,
+                    medianValue: true,
+                    userTimings: [UserTiming.build(name: "mark1", duration: new Double(600), type: UserTimingType.MEASURE)],
+                    flush: true
+            )
+        }
+
+        when: "the builder is configured for measurand and userTimings and jobGroup and excludes a page"
+        SelectedMeasurand selectedMeasurand1 = new SelectedMeasurand("_UTME_mark1", CachedView.UNCACHED)
+        SelectedMeasurand selectedMeasurand2 = new SelectedMeasurand("FULLY_LOADED_TIME", CachedView.UNCACHED)
+        def result = new EventResultQueryBuilder(0, 1000)
+                .withJobGroupIdsIn([jobGroup1.id])
+                .withSelectedMeasurands([selectedMeasurand1, selectedMeasurand2])
+                .withoutPageIn([page3])
+                .getAverageData()
+
+        then: "the result with excluded page is not included in averages"
+        result.size() == 1
+        result.every {
+            it.mark1 == (100 + 200) / 2 &&
+                    it.fullyLoadedTimeInMillisecs == (100 + 200) / 2 &&
                     it.jobGroupId == jobGroup1.id
         }
     }

--- a/src/integration-test/groovy/de/iteratec/osm/result/dao/EventResultQueryBuilderMedianIntegrationSpec.groovy
+++ b/src/integration-test/groovy/de/iteratec/osm/result/dao/EventResultQueryBuilderMedianIntegrationSpec.groovy
@@ -493,7 +493,7 @@ class EventResultQueryBuilderMedianIntegrationSpec extends NonTransactionalInteg
         def result = new EventResultQueryBuilder(0, 1000)
                 .withJobGroupIdsIn([jobGroup1.id])
                 .withSelectedMeasurands([selectedMeasurand1, selectedMeasurand2])
-                .withoutPageIdsIn([page3.id])
+                .withoutPageIn([page3])
                 .getMedianData()
 
         then: "only one aggregation is returned"

--- a/src/integration-test/groovy/de/iteratec/osm/result/dao/EventResultQueryBuilderMedianIntegrationSpec.groovy
+++ b/src/integration-test/groovy/de/iteratec/osm/result/dao/EventResultQueryBuilderMedianIntegrationSpec.groovy
@@ -222,6 +222,56 @@ class EventResultQueryBuilderMedianIntegrationSpec extends NonTransactionalInteg
         }
     }
 
+    void "excluding pages in measurand median calculation for jobGroup"() {
+        given: "three EventResults with valid and some with excluded page"
+        page1 = Page.build()
+        page2 = Page.build()
+        page3 = Page.build()
+        jobGroup1 = JobGroup.build()
+
+        EventResult.build(
+                page: page1,
+                jobGroup: jobGroup1,
+                fullyLoadedTimeInMillisecs: 100,
+                medianValue: true,
+        )
+        EventResult.build(
+                page: page2,
+                jobGroup: jobGroup1,
+                fullyLoadedTimeInMillisecs: 200,
+                medianValue: true,
+        )
+        EventResult.build(
+                page: page2,
+                jobGroup: jobGroup1,
+                fullyLoadedTimeInMillisecs: 300,
+                medianValue: true,
+        )
+        2.times {
+            EventResult.build(
+                    page: page3,
+                    jobGroup: jobGroup1,
+                    fullyLoadedTimeInMillisecs: 1000,
+                    medianValue: true,
+            )
+        }
+
+        when: "the builder is configured for measurand and jobGroup"
+        SelectedMeasurand selectedMeasurand = new SelectedMeasurand("FULLY_LOADED_TIME", CachedView.UNCACHED)
+        def result = new EventResultQueryBuilder(0, 1000)
+                .withJobGroupIdsIn([jobGroup1.id])
+                .withSelectedMeasurands([selectedMeasurand])
+                .withoutPageIn([page3])
+                .getMedianData()
+
+        then: "only one aggregation is returned"
+        result.size() == 1
+        result.every {
+            it.fullyLoadedTimeInMillisecs == 200 &&
+                    it.jobGroupId == jobGroup1.id
+        }
+    }
+
     void "check median for userTimings with jobGroup"() {
         given: "three matching and two other Eventresults"
             page1 = Page.build()
@@ -278,6 +328,65 @@ class EventResultQueryBuilderMedianIntegrationSpec extends NonTransactionalInteg
         }
     }
 
+    void "excluding pages in userTimings median calculation for jobGroup"() {
+        given: "three EventResults with valid and some with excluded page"
+        page1 = Page.build()
+        page2 = Page.build()
+        page3 = Page.build()
+        jobGroup1 = JobGroup.build()
+
+        EventResult.build(
+                page: page1,
+                jobGroup: jobGroup1,
+                fullyLoadedTimeInMillisecs: 500,
+                medianValue: true,
+                userTimings: [UserTiming.build(name: "mark1", duration: new Double(100), type: UserTimingType.MEASURE)],
+                flush: true
+        )
+        EventResult.build(
+                page: page2,
+                jobGroup: jobGroup1,
+                fullyLoadedTimeInMillisecs: 500,
+                medianValue: true,
+                userTimings: [UserTiming.build(name: "mark1", duration: new Double(200), type: UserTimingType.MEASURE)],
+                flush: true
+        )
+        EventResult.build(
+                page: page2,
+                jobGroup: jobGroup1,
+                fullyLoadedTimeInMillisecs: 500,
+                medianValue: true,
+                userTimings: [UserTiming.build(name: "mark1", duration: new Double(300), type: UserTimingType.MEASURE)],
+                flush: true
+        )
+
+        2.times {
+            EventResult.build(
+                    page: page3,
+                    jobGroup: jobGroup1,
+                    fullyLoadedTimeInMillisecs: 500,
+                    medianValue: true,
+                    userTimings: [UserTiming.build(name: "mark1", duration: new Double(1000), type: UserTimingType.MEASURE)],
+                    flush: true
+            )
+        }
+
+        when: "the builder is configured for usertiming and jobGroup"
+        SelectedMeasurand selectedMeasurand = new SelectedMeasurand("_UTME_mark1", CachedView.UNCACHED)
+        def result = new EventResultQueryBuilder(0, 1000)
+                .withJobGroupIdsIn([jobGroup1.id])
+                .withSelectedMeasurands([selectedMeasurand])
+                .withoutPageIn([page3])
+                .getMedianData()
+
+        then: "only one aggregation is returned"
+        result.size() == 1
+        result.every {
+            it.mark1 == 200 &&
+                    it.jobGroupId == jobGroup1.id
+        }
+    }
+
     void "check median for measurands and userTimings with jobGroup"() {
         given: "three matching and two other Eventresults"
             page1 = Page.build()
@@ -324,6 +433,67 @@ class EventResultQueryBuilderMedianIntegrationSpec extends NonTransactionalInteg
         def result = new EventResultQueryBuilder(0, 1000)
                 .withJobGroupIdsIn([jobGroup1.id])
                 .withSelectedMeasurands([selectedMeasurand1, selectedMeasurand2])
+                .getMedianData()
+
+        then: "only one aggregation is returned"
+        result.size() == 1
+        result.every {
+            it.mark1 == 200 &&
+                    it.fullyLoadedTimeInMillisecs == 200 &&
+                    it.jobGroupId == jobGroup1.id
+        }
+    }
+
+    void "excluding pages in measurand and userTimings median calculation for jobGroup"() {
+        given: "three EventResults with valid and some with excluded page"
+        page1 = Page.build()
+        page2 = Page.build()
+        page3 = Page.build()
+        jobGroup1 = JobGroup.build()
+
+        EventResult.build(
+                page: page1,
+                jobGroup: jobGroup1,
+                fullyLoadedTimeInMillisecs: 100,
+                medianValue: true,
+                userTimings: [UserTiming.build(name: "mark1", duration: new Double(100), type: UserTimingType.MEASURE)],
+                flush: true
+        )
+        EventResult.build(
+                page: page2,
+                jobGroup: jobGroup1,
+                fullyLoadedTimeInMillisecs: 200,
+                medianValue: true,
+                userTimings: [UserTiming.build(name: "mark1", duration: new Double(200), type: UserTimingType.MEASURE)],
+                flush: true
+        )
+        EventResult.build(
+                page: page2,
+                jobGroup: jobGroup1,
+                fullyLoadedTimeInMillisecs: 300,
+                medianValue: true,
+                userTimings: [UserTiming.build(name: "mark1", duration: new Double(300), type: UserTimingType.MEASURE)],
+                flush: true
+        )
+
+        2.times {
+            EventResult.build(
+                    page: page3,
+                    jobGroup: jobGroup1,
+                    fullyLoadedTimeInMillisecs: 500,
+                    medianValue: true,
+                    userTimings: [UserTiming.build(name: "mark1", duration: new Double(500), type: UserTimingType.MEASURE)],
+                    flush: true
+            )
+        }
+
+        when: "the builder is configured for usertiming and measurand with jobGroup"
+        SelectedMeasurand selectedMeasurand1 = new SelectedMeasurand("_UTME_mark1", CachedView.UNCACHED)
+        SelectedMeasurand selectedMeasurand2 = new SelectedMeasurand("FULLY_LOADED_TIME", CachedView.UNCACHED)
+        def result = new EventResultQueryBuilder(0, 1000)
+                .withJobGroupIdsIn([jobGroup1.id])
+                .withSelectedMeasurands([selectedMeasurand1, selectedMeasurand2])
+                .withoutPageIdsIn([page3.id])
                 .getMedianData()
 
         then: "only one aggregation is returned"

--- a/src/main/groovy/de/iteratec/osm/result/dao/EventResultQueryBuilder.groovy
+++ b/src/main/groovy/de/iteratec/osm/result/dao/EventResultQueryBuilder.groovy
@@ -110,6 +110,14 @@ class EventResultQueryBuilder {
         return withAssociatedDomainIdsIn(pages.collect { it.ident() }, 'page', project)
     }
 
+    EventResultQueryBuilder withoutPageIn(List<Long> pages) {
+        return withAssociatedDomainIdsNotIn(pages.collect { it.ident() }, 'page')
+    }
+
+    EventResultQueryBuilder withoutPageIdsIn(List<Long> pageIds) {
+        return withAssociatedDomainIdsNotIn(pageIds, 'page')
+    }
+
     EventResultQueryBuilder withCachedView(CachedView cachedView) {
         filters.add({
             'eq' 'cachedView', cachedView
@@ -152,6 +160,16 @@ class EventResultQueryBuilder {
             if (project) {
                 return withProjectedIdForAssociatedDomain(associatedDomainFieldName)
             }
+        }
+        return this
+    }
+
+    private EventResultQueryBuilder withAssociatedDomainIdsNotIn(List<Long> associatedDomainIds, String associatedDomainFieldName) {
+        if (associatedDomainIds) {
+            Closure filterClosure = {
+                not {'in' "${associatedDomainFieldName}.id", associatedDomainIds}
+            }
+            filters.add(filterClosure)
         }
         return this
     }

--- a/src/main/groovy/de/iteratec/osm/result/dao/EventResultQueryBuilder.groovy
+++ b/src/main/groovy/de/iteratec/osm/result/dao/EventResultQueryBuilder.groovy
@@ -110,12 +110,8 @@ class EventResultQueryBuilder {
         return withAssociatedDomainIdsIn(pages.collect { it.ident() }, 'page', project)
     }
 
-    EventResultQueryBuilder withoutPageIn(List<Long> pages) {
+    EventResultQueryBuilder withoutPageIn(List<Page> pages) {
         return withAssociatedDomainIdsNotIn(pages.collect { it.ident() }, 'page')
-    }
-
-    EventResultQueryBuilder withoutPageIdsIn(List<Long> pageIds) {
-        return withAssociatedDomainIdsNotIn(pageIds, 'page')
     }
 
     EventResultQueryBuilder withCachedView(CachedView cachedView) {


### PR DESCRIPTION
In JobAggregation chart, all results within the group got included in calculated average or median values. That includes results of measurement steps which weren't associated to a valid Page (i.e. Page UNDEFINED) also.
Now all results of undefined pages get ignored. 

We used measurement steps without associated page as prewarming steps in some scripts for example.