### PR TITLE
[IT-2427] removed delete mappings button from page view

### DIFF
--- a/grails-app/views/csiConfiguration/_confDetails.gsp
+++ b/grails-app/views/csiConfiguration/_confDetails.gsp
@@ -81,19 +81,21 @@
                                                     'bottomOffsetXAxis': 364, 'yAxisRightOffset': 44, 'chartBottomOffset': 250,
                                                     'yAxisTopOffset'   : 8, 'bottomOffsetLegend': 220, 'modal': false]}"/>
                                 <div class="col-md-4">
-                                    <sec:ifAllGranted roles="ROLE_SUPER_ADMIN">
-                                        <button href="#" type="button" class="btn btn-primary"
-                                                style="display: none;"
-                                                id="removePageMapping"
-                                                onclick="removeSelectedPageMapping('${createLink(controller: 'csiConfiguration', action: 'removePageMapping')}',
-                                                    actualCsiConfigurationId);">
-                                            <g:message
-                                                    code="de.iteratec.osm.csi.configuration.pagemapping.remove.label"
-                                                    default="Remove Mapping"/>
-                                        </button>
+                                    <g:if test="${!hideDeleteMappingButton}">
+                                        <sec:ifAllGranted roles="ROLE_SUPER_ADMIN">
+                                            <button href="#" type="button" class="btn btn-primary"
+                                                    style="display: none;"
+                                                    id="removePageMapping"
+                                                    onclick="removeSelectedPageMapping('${createLink(controller: 'csiConfiguration', action: 'removePageMapping')}',
+                                                        actualCsiConfigurationId);">
+                                                <g:message
+                                                        code="de.iteratec.osm.csi.configuration.pagemapping.remove.label"
+                                                        default="Remove Mapping"/>
+                                            </button>
 
-                                        <div id="page-mapping-deletions"></div>
-                                    </sec:ifAllGranted>
+                                            <div id="page-mapping-deletions"></div>
+                                        </sec:ifAllGranted>
+                                    </g:if>
                                 </div>
                             </div>
                         </g:if>

--- a/grails-app/views/csiConfiguration/configurations.gsp
+++ b/grails-app/views/csiConfiguration/configurations.gsp
@@ -262,7 +262,8 @@
                                              matrixViewData          : matrixViewData,
                                              treemapData             : treemapData,
                                              barchartData            : barchartData,
-                                             pageTimeToCsMappings    : pageTimeToCsMappings]"/>
+                                             pageTimeToCsMappings    : pageTimeToCsMappings,
+                                             hideDeleteMappingButton : false]"/>
 
 </div>
 %{-- initially invisible modal dialog to update csi configuratuion via ajax --}%

--- a/grails-app/views/jobGroup/show.gsp
+++ b/grails-app/views/jobGroup/show.gsp
@@ -192,7 +192,8 @@
         <g:render template="/csiConfiguration/confDetails" model="[readOnly               : true,
                                                                    showDefaultMappings    : false,
                                                                    defaultTimeToCsMappings: defaultTimeToCsMappings,
-                                                                   pageMappingsExist      : pageMappingsExist]"/>
+                                                                   pageMappingsExist      : pageMappingsExist,
+                                                                   hideDeleteMappingButton: true]"/>
     </g:if>
 </section>
 <content tag="include.bottom">


### PR DESCRIPTION
The button was misleading, because it seems like one would only edit this particular JobGroup, but instead deleting would affect all JobGroups assigned to this particular CsiConfiguration.