### PR TITLE
[IT-2410] fixed csi graph width

### DIFF
--- a/frontend/src/app/application-dashboard/components/csi-graph/csi-graph.component.scss
+++ b/frontend/src/app/application-dashboard/components/csi-graph/csi-graph.component.scss
@@ -2,6 +2,7 @@
 
 osm-csi-graph {
   display: block;
+  width: 100%;
 
   .csi-graph-svg {
     height: 100%;


### PR DESCRIPTION
On page load the CSI Graphs width was too wide, so the graph partially disappeared. 
The graph is now fixed to 100% width of the parent.