### PR TITLE
Save calculated CSI before update event, explicitly flush it

### DIFF
--- a/grails-app/services/de/iteratec/osm/csi/JobGroupCsiAggregationService.groovy
+++ b/grails-app/services/de/iteratec/osm/csi/JobGroupCsiAggregationService.groovy
@@ -198,8 +198,8 @@ class JobGroupCsiAggregationService {
             if (weightedCsiValuesVisuallyComplete.size() > 0) {
                 toBeCalculated.csByWptVisuallyCompleteInPercent = meanCalcService.calculateWeightedMean(weightedCsiValuesVisuallyComplete*.weightedValue)
             }
+            toBeCalculated.save(failOnError: true, flush: true)
             csiAggregationUpdateEventDaoService.createUpdateEvent(toBeCalculated.ident(), CsiAggregationUpdateEvent.UpdateCause.CALCULATED)
-            toBeCalculated.save(failOnError: true)
         }
         return csiAggregationsToCalculate
     }


### PR DESCRIPTION
Otherwise the calculated CSI was sometimes not flushed to the database (for some reason) and the existing update event prevented it from being recalculated.