### PR TITLE
Only add a job group to the application list if it is not already exists in the list

### DIFF
--- a/grails-app/services/de/iteratec/osm/measurement/schedule/JobGroupService.groovy
+++ b/grails-app/services/de/iteratec/osm/measurement/schedule/JobGroupService.groovy
@@ -83,14 +83,16 @@ class JobGroupService {
                 formattedLastDateOfResult = lastDateOfResult.date?.format("yyyy-MM-dd")
             }
 
-            allActiveAndRecentFormattedJobGroups.add(
-                    [
-                            id                : it.id,
-                            name              : it.name,
-                            dateOfLastResults : formattedLastDateOfResult,
-                            csiConfigurationId: it.csiConfigurationId
-                    ]
-            )
+            if (!allActiveAndRecentFormattedJobGroups.find { jobGroup -> jobGroup.id == it.id }) {
+                allActiveAndRecentFormattedJobGroups.add(
+                        [
+                                id                : it.id,
+                                name              : it.name,
+                                dateOfLastResults : formattedLastDateOfResult,
+                                csiConfigurationId: it.csiConfigurationId
+                        ]
+                )
+            }
         }
 
         return allActiveAndRecentFormattedJobGroups


### PR DESCRIPTION
If a job group is measured activly and has valid results, the job group appears two times in the application list. 
-> Only add a job group once to the application list.