### PR TITLE
only set default to english if browser language is not german and not…

### DIFF
--- a/grails-app/views/_common/_jsGlobals.gsp
+++ b/grails-app/views/_common/_jsGlobals.gsp
@@ -11,7 +11,7 @@
         var lang = '${session.'org.springframework.web.servlet.i18n.SessionLocaleResolver.LOCALE'}';
         if (!lang) {
             lang = navigator.language.substr(0, 2);
-            if (lang != "en" || lang != "de") {
+            if (lang != "en" && lang != "de") {
                 lang = "en";
             }
         }


### PR DESCRIPTION
ensure that the default language can be also german by fixing the check for not supported languages. Now english will only be chosen if there is no language info within the session and the browser's english or not english and not german.