### PR TITLE
Removed spinner if no data was available in pageAggregation…

### DIFF
--- a/grails-app/assets/javascripts/pageAggregation/pageAggregationGuiHandling.js
+++ b/grails-app/assets/javascripts/pageAggregation/pageAggregationGuiHandling.js
@@ -174,6 +174,7 @@ OpenSpeedMonitor.ChartModules.GuiHandling.pageAggregation = (function () {
 
         if ($.isEmptyObject(data)) {
             $('#warning-no-data').show();
+            spinner.stop();
             return;
         }
 


### PR DESCRIPTION
If no data was available for the selection on Page Aggregation Chart, the spinner would never disappear. 
For now the spinner will disappear, but the last graph shown will still be there. This should be target in the future.