### PR TITLE
Docker: Allow user independet usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM java:openjdk-8
-MAINTAINER nils.kuhn@iteratec.de, birger.kamp@iteratec.de
 
-#ENV OSM_VERSION 3.4.8-build293
 ENV OSM_HOME /osm
-ENV OSM_CONFIG_HOME /home/osm/.grails
+ENV OSM_CONFIG_HOME /osm/config
 ENV JAVA_OPTS "-server -Dgrails.env=prod -Dfile.encoding=UTF-8"
 ENV DOCKERIZE_VERSION v0.3.0
 
@@ -16,7 +14,10 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 # get osm-sources and build war-file
-RUN mkdir -p $OSM_HOME $OSM_HOME/logs $OSM_CONFIG_HOME
+RUN mkdir -p $OSM_HOME $OSM_HOME/logs $OSM_CONFIG_HOME && \
+    chmod -R 775 $OSM_HOME $OSM_CONFIG_HOME && \
+    chown -R osm:100 $OSM_HOME $OSM_CONFIG_HOME
+
 WORKDIR $OSM_HOME
 ADD ./build/libs/OpenSpeedMonitor*.war $OSM_HOME/
 
@@ -25,8 +26,7 @@ ADD docker/templates/osm-config.yml.j2 $OSM_CONFIG_HOME/OpenSpeedMonitor-config.
 
 # add entrypoint script
 ADD docker/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh && \
-    chown osm:osm -R $OSM_HOME $OSM_CONFIG_HOME
+RUN chmod 775 /entrypoint.sh
 
 USER osm
 EXPOSE 8080

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,4 +7,4 @@ echo "complete osm config file gets prepared"
 dockerize -template $OSM_CONFIG_TARGET_LOCATION.j2:$OSM_CONFIG_TARGET_LOCATION
 
 # start tomcat
-java -Dgrails.env=prod -jar $OSM_HOME/OpenSpeedMonitor*.war
+java -Dgrails.env=prod -Dosm_config_location=${OSM_CONFIG_TARGET_LOCATION} -jar $OSM_HOME/OpenSpeedMonitor*.war

--- a/docker/templates/osm-config.yml.j2
+++ b/docker/templates/osm-config.yml.j2
@@ -25,7 +25,7 @@ environments:
     grails:
       serverURL: '{{ default .Env.OSM_URL "http://localhost:8080"}}'
       de.iteratec.osm.detailAnalysis:
-        enablePersistenceOfDetailAnalysisData: {{ default .Env.ENABLE_DETAIL_ANALYSIS false }}
+        enablePersistenceOfDetailAnalysisData: {{ default .Env.ENABLE_DETAIL_ANALYSIS "false" }}
         microserviceUrl: '{{ default .Env.DETAIL_ANALYSIS_URL "http://your.detail.analysis.service.com" }}'
         apiKey: '{{ default .Env.API_KEY_DETAIL_ANALYSIS "apiKeyForDetailAnalysisService" }}'
     dataSource:


### PR DESCRIPTION
Systems like OpenShift do not guarantee that a image is actually run with the user specified in it.
This caused problems as the image relied on using the $HOME variable and being user 'osm' with specific rights.

Now the user only needs to be in the user group and the rest works with arbitrary users.