### PR TITLE
fix persisting results

### DIFF
--- a/grails-app/services/de/iteratec/osm/measurement/environment/wptserver/WptInstructionService.groovy
+++ b/grails-app/services/de/iteratec/osm/measurement/environment/wptserver/WptInstructionService.groovy
@@ -178,13 +178,13 @@ class WptInstructionService {
                     if (listener.callListenerAsync()) {
                         Promise p = task {
                             JobResult.withNewSession {
-                                listener.listenToResult(resultXml, wptserverOfResult, job)
+                                listener.listenToResult(resultXml, wptserverOfResult, job.id)
                             }
                         }
                         p.onError { Throwable err -> log.error("${listener.getListenerName()} failed persisting results", err) }
                         p.onComplete { log.info("${listener.getListenerName()} successfully returned from async task") }
                     } else {
-                        listener.listenToResult(resultXml, wptserverOfResult, job)
+                        listener.listenToResult(resultXml, wptserverOfResult, job.id)
                     }
                 }
 

--- a/src/test/groovy/de/iteratec/osm/measurement/environment/wptserver/PersistingNewEventResultsSpec.groovy
+++ b/src/test/groovy/de/iteratec/osm/measurement/environment/wptserver/PersistingNewEventResultsSpec.groovy
@@ -344,7 +344,7 @@ class PersistingNewEventResultsSpec extends Specification implements BuildDataTe
         Job job = Job.build(label: "testjob")
 
         when: "the service tries to persist results for an XML result with failed step"
-        service.persistResultsForAllTeststeps(xmlResult, job.id)
+        service.persistResultsForAllTeststeps(xmlResult, job)
 
         then: "it throws an exception and doesn't create any measured events"
         MeasuredEvent.list().size() == 0


### PR DESCRIPTION
- Fixed function call of listenToResult.
- Load job only once in listenToResult function.
