### PR TITLE
Bug fix: FrontendWatcher Windows

### DIFF
--- a/grails-app/init/de/iteratec/osm/FrontendWatcher.groovy
+++ b/grails-app/init/de/iteratec/osm/FrontendWatcher.groovy
@@ -25,8 +25,7 @@ class FrontendWatcher {
     protected void startFrontendWatcher(Environment environment) {
 
         String location = environment.getReloadLocation()
-        //def nodeLocation = new File(new FileNameByRegexFinder().getFileNames(location, "/build/nodejs/([^\\\\/]*)/bin/node")[0]).getParent()
-        //def nodeExecLocation = new FileNameByRegexFinder().getFileNames( location, "build[\\\\/]nodejs[\\\\/]([^\\\\/]*)[\\\\/]((node\\.exe+)|(bin/node))")[0]
+
         def nodeExecLocation = new FileNameByRegexFinder().getFileNames( Paths.get(location, "build", "nodejs").toString(), "[\\\\/]([^\\\\/]*)[\\\\/]((node\\.exe+)|(bin/node))")[0]
         def nodeLocation = new File( nodeExecLocation ).getParent()
 

--- a/grails-app/init/de/iteratec/osm/FrontendWatcher.groovy
+++ b/grails-app/init/de/iteratec/osm/FrontendWatcher.groovy
@@ -23,14 +23,12 @@ class FrontendWatcher {
 
     @CompileDynamic
     protected void startFrontendWatcher(Environment environment) {
-
         String location = environment.getReloadLocation()
 
-        def nodeExecLocation = new FileNameByRegexFinder().getFileNames( Paths.get(location, "build", "nodejs").toString(), "[\\\\/]([^\\\\/]*)[\\\\/]((node\\.exe+)|(bin/node))")[0]
-        def nodeLocation = new File( nodeExecLocation ).getParent()
+        String nodeExecLocation = new FileNameByRegexFinder().getFileNames(Paths.get(location, "build", "nodejs").toString(), "([^\\/]*)((node\\.exe+)|(/bin/node(?!.)))")[0]
+        def nodeLocation = new File(nodeExecLocation).getParent()
 
         if (location && nodeLocation) {
-
             Thread.start {
                 def nodeModulesBin = Paths.get("${location}", "frontend", "node_modules", ".bin").toString()
 
@@ -38,7 +36,7 @@ class FrontendWatcher {
                 if( nodeExecLocation.endsWith(".exe") ) { // running on windows?
                     watchBuilder = new ProcessBuilder(["cmd", "/C", "ng build --watch"])
                             .redirectErrorStream(true).directory(new File(location, "frontend"))
-                    watchBuilder.environment().put("PATH", "${nodeModulesBin};${nodeLocation};")
+                    watchBuilder.environment().put("PATH", "${nodeModulesBin};${nodeLocation}")
                 }
                 else {
                     watchBuilder = new ProcessBuilder(['sh', '-c', 'ng build --watch'])

--- a/grails-app/init/de/iteratec/osm/FrontendWatcher.groovy
+++ b/grails-app/init/de/iteratec/osm/FrontendWatcher.groovy
@@ -26,11 +26,11 @@ class FrontendWatcher {
         String location = environment.getReloadLocation()
 
         String nodeExecLocation = new FileNameByRegexFinder().getFileNames(Paths.get(location, "build", "nodejs").toString(), "([^\\/]*)((node\\.exe+)|(/bin/node(?!.)))")[0]
-        def nodeLocation = new File(nodeExecLocation).getParent()
+        String nodeLocation = new File(nodeExecLocation).getParent()
 
         if (location && nodeLocation) {
             Thread.start {
-                def nodeModulesBin = Paths.get("${location}", "frontend", "node_modules", ".bin").toString()
+                String nodeModulesBin = Paths.get("${location}", "frontend", "node_modules", ".bin").toString()
 
                 ProcessBuilder watchBuilder
                 if( nodeExecLocation.endsWith(".exe") ) { // running on windows?
@@ -76,7 +76,7 @@ class FrontendWatcher {
                 while (GrailsApp.developmentModeActive) {
 
                     def uniqueChangedFiles = changedFiles as Set
-                    def uniqueChangedFilesSize = uniqueChangedFiles.size()
+                    int uniqueChangedFilesSize = uniqueChangedFiles.size()
 
                     try {
                         if (uniqueChangedFilesSize >= 1) {


### PR DESCRIPTION
The FrontendWatcher did not work on windows because of path naming and the PATH env-variable.