### PR TITLE
Delete ResultSelectionInformation with nightly cleanup

### DIFF
--- a/grails-app/jobs/de/iteratec/osm/persistence/DbCleanupOldJobResultsWithDependenciesJob.groovy
+++ b/grails-app/jobs/de/iteratec/osm/persistence/DbCleanupOldJobResultsWithDependenciesJob.groovy
@@ -3,8 +3,6 @@ package de.iteratec.osm.persistence
 import de.iteratec.osm.ConfigService
 import de.iteratec.osm.InMemoryConfigService
 import org.joda.time.DateTime
-import org.quartz.JobExecutionException
-
 
 class DbCleanupOldJobResultsWithDependenciesJob {
 
@@ -25,6 +23,7 @@ class DbCleanupOldJobResultsWithDependenciesJob {
         if(inMemoryConfigService.isDatabaseCleanupEnabled()){
             Date toDeleteResultsBefore = new DateTime().minusMonths(configService.getMaxDataStorageTimeInMonths()).toDate()
             dbCleanupService.deleteResultsDataBefore(toDeleteResultsBefore, createBatchActivity)
+            dbCleanupService.deleteResultSelectionInformationBefore(toDeleteResultsBefore, createBatchActivity)
         }
     }
 }

--- a/src/test/groovy/de/iteratec/osm/persistence/DbCleanupServiceSpec.groovy
+++ b/src/test/groovy/de/iteratec/osm/persistence/DbCleanupServiceSpec.groovy
@@ -27,7 +27,6 @@ import de.iteratec.osm.report.chart.CsiAggregation
 import de.iteratec.osm.report.chart.CsiAggregationUpdateEvent
 import de.iteratec.osm.result.EventResult
 import de.iteratec.osm.result.JobResult
-import de.iteratec.osm.result.MeasuredEvent
 import de.iteratec.osm.result.ResultSelectionInformation
 import grails.buildtestdata.BuildDataTest
 import grails.buildtestdata.mixin.Build

--- a/src/test/groovy/de/iteratec/osm/persistence/DbCleanupServiceSpec.groovy
+++ b/src/test/groovy/de/iteratec/osm/persistence/DbCleanupServiceSpec.groovy
@@ -27,13 +27,14 @@ import de.iteratec.osm.report.chart.CsiAggregation
 import de.iteratec.osm.report.chart.CsiAggregationUpdateEvent
 import de.iteratec.osm.result.EventResult
 import de.iteratec.osm.result.JobResult
+import de.iteratec.osm.result.ResultSelectionInformation
 import grails.buildtestdata.BuildDataTest
 import grails.buildtestdata.mixin.Build
 import grails.testing.services.ServiceUnitTest
 import org.joda.time.DateTime
 import spock.lang.Specification
 
-@Build([JobResult, EventResult, CsiAggregation, CsiAggregationUpdateEvent])
+@Build([JobResult, EventResult, ResultSelectionInformation, CsiAggregation, CsiAggregationUpdateEvent])
 class DbCleanupServiceSpec extends Specification implements BuildDataTest, ServiceUnitTest<DbCleanupService> {
 
     static final Date OLDER_12_MONTHS = new DateTime(2014,2,9,0,0,0).toDate()

--- a/src/test/groovy/de/iteratec/osm/persistence/DbCleanupServiceSpec.groovy
+++ b/src/test/groovy/de/iteratec/osm/persistence/DbCleanupServiceSpec.groovy
@@ -90,7 +90,7 @@ class DbCleanupServiceSpec extends Specification implements BuildDataTest, Servi
 
         when: "deleteResultsDataBefore is called with toDeleteBefore 12 months ago."
         Date twelveMonthsAgo = new DateTime().minusMonths(12).toDate()
-        service.deleteResultsDataBefore(twelveMonthsAgo)
+        service.deleteResultSelectionInformationBefore(twelveMonthsAgo)
 
         then: "ResultSelectionInformation older 12 months got deleted, the rest still exists."
         ResultSelectionInformation.list().size() == 1


### PR DESCRIPTION
The database cleanup service deletes job results and event results that are older than 12 months. This pull request also deletes the associated result selection information so that the OpenSpeedMonitor does not offer selections for deleted job results.