### PR TITLE
Correct spelling errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,27 +13,27 @@ Summary
 =====================
 OpenSpeedMonitor automates web performance measurements based on [WebPagetest][1]. It also processes, aggregates and visualizes the results. So it perfectly fits the need for a continuous monitoring of your most important pages.
 
-_The timings you have to keep track of - always on expressive, well arranged dashboards. Without losing all the details of the single WebPagetests if needed!_
+_The timings you have to keep track of - always on expressive, well arranged dashboards. Without losing all the details of the single WebPageTests if needed!_
 
 You want to see it running? No problem, there is a demo up and running at [demo.openspeedmonitor.org][17].
 
 ![Einstieg OSM](https://github.com/IteraSpeed/OpenSpeedMonitor/wiki/images/osm_v4_result_dashboard.jpg)
 
-OpenSpeedMonitor is published under [Apache License 2.0][12], so feel free to use, adapt and do whatever you want with the code. If you extend functionality we would appreciate contributions. Technically, OpenSpeedMonitor is based on [grails][3], a jvm based web framework leveraged by the programming language [groovy][2].
+OpenSpeedMonitor is published under [Apache License 2.0][12], so feel free to use, adapt and do whatever you want with the code. If you extend functionality we would appreciate contributions. Technically, OpenSpeedMonitor is based on [grails][3], a JVM based web framework leveraged by the programming language [groovy][2].
 
 Usage
 =====================
-In the following explanations all references to gui elements of OpenSpeedMonitor are given in English, also gui is internationalized and comes with German as additional language.
+In the following explanations all references to GUI elements of OpenSpeedMonitor are given in English, but the GUI is internationalized and comes with German as additional language.
 
 Construct measurement environment
 ---------------------
-OpenSpeedMonitor is great for automation of web performance measurements as well as for processing, analyzing and visualizing the measurement results. But it doesn't provide anything for actually running the performance measurements. Therefore it is based on [WebPagetest][1] which does the measurement job. So to run OpenSpeedMonitor we assume you have installed and set up a private instance of WebPagetest. This instance should contain at least one wpt server with configured locations and measuring agent(s) behind the locations. An installation guide for private instances of WebPagetest can be found [here][4].
+OpenSpeedMonitor is great for automation of web performance measurements as well as for processing, analyzing and visualizing the measurement results. But it doesn't provide anything for actually running the performance measurements. Therefore, it is based on [WebPageTest][1], which performs the measurements. So to run OpenSpeedMonitor, we assume you have installed and configured a private instance of WebPageTest. This instance should contain at least one WPT server with configured locations and measuring agent(s) behind the locations. An installation guide for private instances of WebPageTest can be found [here][4].
 
-OpenSpeedMonitor uses the [RESTful API][6] of WebPagetest for automation of performance measurements and getting the result's raw data. If you look at the [system overview][5] of webpagetest OpenSpeedMonitor uses Automation API to run scheduled tests and get back results from wpt server like other external tools.
+OpenSpeedMonitor uses the [RESTful API][6] of WebPageTest for automation of performance measurements and getting the result's raw data. If you look at the [system overview][5] of WebPageTest OpenSpeedMonitor uses Automation API to run scheduled tests and get back results from WPT server like other external tools.
 
-First thing you have to do after installation is to configure the components of your private WebPagetest instance. All you need is a running WebPagetest server which is available via HTTP(S) from your OpenSpeedMonitor instance. After a login you can reach the gui to create a new wpt server object via menu entry `Administration >> All Controllers >> WebPageTestServerController`. You have to set correct _Base Url_ of the wpt server in order to automate tests on that server. After creation of the server object you can use the _Fetch locations_ button in order to get locations configured on that wpt server into OpenSpeedMonitor. That function uses `[wpt server BaseUrl]/getLocations.php` api function of wpt server to request its locations.
+First thing you have to do after installation is to configure the components of your private WebPageTest instance. All you need is a running WebPageTest server which is available via HTTP(S) from your OpenSpeedMonitor instance. After a login you can reach the GUI to create a new WPT server object via menu entry `Administration >> All Controllers >> WebPageTestServerController`. You have to set correct _Base Url_ of the WPT server in order to automate tests on that server. After creation of the server object you can use the _Fetch locations_ button in order to get locations configured on that WPT server into OpenSpeedMonitor. That function uses the API function`[wpt server BaseUrl]/getLocations.php` of the WPT server to request its locations.
 
-For the following environment components objects get created in database of OpenSpeedMonitor (if they don't already exist) while start of OpenSpeedMonitor:
+For the following environment components, objects get created in the OpenSpeedMonitor database (if they don't already exist) at startup:
 
 * Browsers
     * Internet Explorer
@@ -44,17 +44,17 @@ For the following environment components objects get created in database of Open
     * UMTS (384 kbit/s bandwidth down, 384 kbit/s bandwidth up, 140 ms additional RTT, 0 packet loss rate)
     * UMTS - HSDPA (3.600 kbit/s bandwidth down, 1.500 kbit/s bandwidth up, 40 ms additional RTT, 0 packet loss rate)
 
-Additional objects like further browsers and/or connectivity profiles can be created via web gui of OpenSpeedMonitor after start.
+Additional objects such as additional browsers and/or connectivity profiles can be created via the OpenSpeedMonitor web GUI after startup.
 
 Set up measurements
 ---------------------
-After wpt server(s), locations and browsers of your measurement environment are set up you can start to automate web performance measurements for your private WebPagetest instance. To run your first measurement automatically, you will need:
+After WPT server(s), locations and browsers of your measurement environment are set up you can start to automate web performance measurements for your private WebPageTest instance. To run your first measurement automatically, you will need:
 
-* A wpt script
+* A WPT script
 
-    > Describes what the browser should do while test execution. That can be a sequence of different pages illustrating a whole use case of the web application under test. For each of the steps in the sequence a single result will be available after test execution. Single steps should be named via `setEventName` command.
+    > Describes what the browser should do during test execution. This can be a sequence of different pages that illustrate an entire use case of the web application under test. For each of the steps in the sequence a single result will be available after test execution. Single steps should be named via the `setEventName` command.
     >
-    > Scripts has to be written in WebPagetest DSL. See [scripting documentation][7] for details.
+    > Scripts have to be written in WebPageTest DSL. See [scripting documentation][7] for details.
     >
     > Example measuring a single page:
     > ![Script of a single step](https://github.com/IteraSpeed/OpenSpeedMonitor/wiki/images/osm_v4_script_singleStep.png)
@@ -62,26 +62,26 @@ After wpt server(s), locations and browsers of your measurement environment are 
     > Example surfing through an online shop to a product page:
     > ![Script of multiple steps](https://github.com/IteraSpeed/OpenSpeedMonitor/wiki/images/osm_v4_scriptMultistep.png)
     >
-    > If you have any further questions on that feel free to [contact us][15]
+    > If you have any further questions, please do not hesitate to [contact us][15]
 
 * A measurement job
 
-    > Within a job you configure when to run the measurement and on which wpt location and browser to run it. Also you can set all the advanced settings you can set for an ad hoc measurement via web gui of wpt server (like internet connectivity, whether or not to create a video, whether or not to create a tcp dump of the measurement, et cetera).
+    > Within a job you configure when to run the measurement and on which WPT location and browser to run it. You can also specify any advanced settings that you can set for an ad hoc measurement using Web GUI of the WPT server (e.g. Internet connectivity, whether to create a video or not, whether to create a TCP dump of the measurement or not, et cetera).
 
-Views for managing scripts and jobs are available in _Measurement_ section of OpenSpeedMonitor gui. The list views can be filtered. Filters get persisted in local storage of your browser so you don't lose your settings while navigating through application.
+Views for managing scripts and jobs are available in the _Measurement_ section of the OpenSpeedMonitor GUI. The list views can be filtered. Filters get persisted in the local storage of your browser, so that you do not lose your settings when navigating through the application.
 
-After each start of OpenSpeedMonitor application, measurements are disabled generally. So even if you set up measurements as described in previous section none of your measurement jobs will start any measurements at all. You will have to activate measurements once, initially on job list view (requires login with admin rights).
+Each time the OpenSpeedMonitor application is started, the measurements are generally disabled. So even if you set up measurements as described in previous section, none of your measurement jobs will start any measurements at all. You will have to activate the measurements once, initially in the job list view (requires login with admin rights).
 
 Visualize results
 ---------------------
 
 **Raw test result data**
 
-Trends in time of wpt results are available in _Measurement results_ section.
+Trends in time of WPT results are available in _Measurement results_ section.
 
 ![resultchart](https://github.com/IteraSpeed/OpenSpeedMonitor/wiki/images/osm_v4_resultchart.jpg)
 
-Measurement data to show in diagrams can be chosen by three categories which are located in three different areas within the gui.
+Measurement data to be displayed in diagrams can be selected by three categories located in three different areas within the GUI.
 
 * _Aggregation and timeframe_
 
@@ -89,11 +89,11 @@ Measurement data to show in diagrams can be chosen by three categories which are
 
 * _Filter jobs_
 
-    One can filter the results of which jobs to show. Measurement jobs can be associated to groups. Webpage types (like _homepage_ or _product page_ of online shops) can be configured and associated to measured steps. Browser and/or location tests run on can be used as filter criteria.
+    One can filter the results of which jobs to show. Measurement jobs can be assigned to groups. Webpage types (like _homepage_ or _product page_ of online shops) can be configured and assigned to the measured steps. Browser and/or location tests can be used as filter criteria.
 
 * _Choose measured variables_
 
-    All the data WebPagetest provides on page level (first and repeated view) can be shown in diagrams of OpenSpeedMonitor. The measurands are categorized as follows for convenient selection and for association to different y-axes of diagram:
+    All the data WebPageTest provides on page level (first and repeated view) can be shown in diagrams of OpenSpeedMonitor. The measurands are categorized as follows for convenient selection and assignment to different y-axes of the diagram:
 
     * Load times
         * load time
@@ -115,11 +115,11 @@ Measurement data to show in diagrams can be chosen by three categories which are
     * Others
         * speed index
 
-Single data points are clickable and lead to underlying WebPagetest result with all its details.
+Single data points are clickable and lead to the underlying WebPageTest result with all its details.
 
 **Results aggregated by measured pages**
 
-All the raw data measured with WebPagetest can be aggregated by page. These aggregations get visualized as barcharts on a dashboard.
+All the raw data measured with WebPageTest can be aggregated by page. These aggregations get visualized as barcharts on a dashboard.
 
 ![resultchart](https://github.com/IteraSpeed/OpenSpeedMonitor/wiki/images/osm_v4_page_aggregation.jpg)
 
@@ -130,7 +130,7 @@ Detail Analysis
 
 ![OsmDetailAnalysis](https://github.com/IteraSpeed/OpenSpeedMonitor/wiki/images/osm_v4_detailanalysis.jpg)
 
-These sort of analysis can be of great benefit detecting third party libraries that slow down your site!
+These type of analysis can be of great benefit detecting third-party libraries that slow down your site!
 
 OsmDetailAnalysis is open source and licensed under same licence as OpenSpeedMonitor.
 
@@ -144,7 +144,7 @@ Compatibility with OpenSpeedMonitor:
 Customer satisfaction index (CSI)
 ---------------------
 
-Usually different pages of your application are of greatest interest regarding performance. To compare these different pages raw pageload times aren't always best measurand quantity. Your users may expect and accept different load times for different types of pages. For example, 2.8 secs may be acceptable for the basket of your online shop, while it may absolutely not be acceptable for the homepage.
+Usually different pages of your application are of greatest interest regarding performance. To compare these different pages, raw pageload times are not always the best measure. Your users may expect and accept different load times for different types of pages. For example, 2.8 secs may be acceptable for the basket of your online shop, while it may be absolutely unacceptable for the homepage.
 
 To take that fact into account OpenSpeedMonitor can translate load times of every test result into a percentage of customers who would be satisfied with that load time. OpenSpeedMonitor comes with five predefined mappings.
 
@@ -152,11 +152,11 @@ To take that fact into account OpenSpeedMonitor can translate load times of ever
 
 To translate load times into percentages of satisfaction one of these mappings can be applied to all your measured page types.
 
-Further, OpenSpeedMonitor provides possibility to calculate aggregated customer satisfaction indices for all the pages of your application and for the whole application altogether. Results factored in the calculation of the pages csi get weighted by browser, connectivity and hour of day regarding their importance for your application. Results factored in the calculation of applications csi get weighted by pages regarding their importance for your application.
+In addition, OpenSpeedMonitor provides the ability to calculate aggregated customer satisfaction indices for all the pages of your application and for the entire application. Results factored in the calculation of the pages CSI are weighted by browser, connectivity and hour of day to determine their importance for your application. Results factored in the calculation of applications CSI are weighted by pages according to their importance for your application.
 
 ![page weights](https://github.com/IteraSpeed/OpenSpeedMonitor/wiki/images/osm_v4_pageweights.png)
 
-The CSI is a KPI very suitable for getting a quick overview of the overall performance of your whole application. It can be used to setup a competition benchmark in your branch of business.
+The CSI is a KPI that is very suitable for getting a quick overview of the overall performance of your entire application. It can be used to setup a competitive benchmark in your branch of business.
 
 ![csi competition benchmark](https://github.com/IteraSpeed/OpenSpeedMonitor/wiki/images/osm_v4_csi_chart.jpg)
 
@@ -183,9 +183,9 @@ Prerequisites
 
 Installation OpenSpeedMonitor
 ---------------------
-As a [grails][3] application OpenSpeedMonitor is jvm and servlet API based. So its runtime environment is a servlet container. The deployment artefact of servlet API based web applications is a war file (web application archive).
+As a [grails][3] application OpenSpeedMonitor is JVM and servlet API based. So its runtime environment is a servlet container. The deployment artefact of servlet API based web applications is a WAR file (web application archive).
 
-One way to install OpenSpeedMonitor is to create a war file through running _gradle assemble_.
+One way to install OpenSpeedMonitor is to create a WAR file through running _gradle assemble_.
 
 From project root on Linux/MAC:
 
@@ -195,7 +195,7 @@ or on Windows:
 
     ./gradlew.bat assemble
 
-Created war file can be deployed to servlet container of choice.
+Created WAR file can be deployed to servlet container of choice.
 See [grails build documentation][10] for details.
 
 Since version 3 Grails is based on Spring Boot and so can be run easily **in embedded tomcat container**.
@@ -208,7 +208,7 @@ or on Windows:
 
     ./gradlew.bat -Dgrails.env=prod bootRun
 
-Created war file can be deployed to servlet container of choice.
+Created WAR file can be deployed to servlet container of choice.
 See [grails build documentation][10] for details.
 
 Like described in previous prerequisites section OpenSpeedMonitor can be deployed and run in docker containers. One can use docker-compose file _docker/docker-compose.yml_  to start multiple containers via this simple call:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Summary
 =====================
 OpenSpeedMonitor automates web performance measurements based on [WebPagetest][1]. It also processes, aggregates and visualizes the results. So it perfectly fits the need for a continuous monitoring of your most important pages.
 
-_The timings you have to keep track of - always on expressive, well arranged dashboards. Without loosing all the details of the single WebPagetests if needed!_
+_The timings you have to keep track of - always on expressive, well arranged dashboards. Without losing all the details of the single WebPagetests if needed!_
 
 You want to see it running? No problem, there is a demo up and running at [demo.openspeedmonitor.org][17].
 
@@ -23,7 +23,7 @@ OpenSpeedMonitor is published under [Apache License 2.0][12], so feel free to us
 
 Usage
 =====================
-In the following explanations all references to gui elements of OpenSpeedMonitor are given in english, also gui is internationalized and comes with german as additional language.
+In the following explanations all references to gui elements of OpenSpeedMonitor are given in English, also gui is internationalized and comes with German as additional language.
 
 Construct measurement environment
 ---------------------
@@ -31,7 +31,7 @@ OpenSpeedMonitor is great for automation of web performance measurements as well
 
 OpenSpeedMonitor uses the [RESTful API][6] of WebPagetest for automation of performance measurements and getting the result's raw data. If you look at the [system overview][5] of webpagetest OpenSpeedMonitor uses Automation API to run scheduled tests and get back results from wpt server like other external tools.
 
-First thing you have to do after installation is to configure the components of your private WebPagetest instance. All you need is a running WebPagetest server which is available via HTTP(S) from your OpenSpeedMonitor instance. After a log in you can reach the gui to create a new wpt server object via menu entry `Administration >> All Controllers >> WebPageTestServerController`. You have to set correct _Base Url_ of the wpt server in order to automate tests on that server. After creation of the server object you can use the _Fetch locations_ button in order to get locations configured on that wpt server into OpenSpeedMonitor. That function uses `[wpt server BaseUrl]/getLocations.php` api function of wpt server to request its locations.
+First thing you have to do after installation is to configure the components of your private WebPagetest instance. All you need is a running WebPagetest server which is available via HTTP(S) from your OpenSpeedMonitor instance. After a login you can reach the gui to create a new wpt server object via menu entry `Administration >> All Controllers >> WebPageTestServerController`. You have to set correct _Base Url_ of the wpt server in order to automate tests on that server. After creation of the server object you can use the _Fetch locations_ button in order to get locations configured on that wpt server into OpenSpeedMonitor. That function uses `[wpt server BaseUrl]/getLocations.php` api function of wpt server to request its locations.
 
 For the following environment components objects get created in database of OpenSpeedMonitor (if they don't already exist) while start of OpenSpeedMonitor:
 
@@ -68,7 +68,7 @@ After wpt server(s), locations and browsers of your measurement environment are 
 
     > Within a job you configure when to run the measurement and on which wpt location and browser to run it. Also you can set all the advanced settings you can set for an ad hoc measurement via web gui of wpt server (like internet connectivity, whether or not to create a video, whether or not to create a tcp dump of the measurement, et cetera).
 
-Views for managing scripts and jobs are available in _Measurement_ section of OpenSpeedMonitor gui. The list views can be filtered. Filters get persisted in local storage of your browser so you don't loose your settings while navigating through application.
+Views for managing scripts and jobs are available in _Measurement_ section of OpenSpeedMonitor gui. The list views can be filtered. Filters get persisted in local storage of your browser so you don't lose your settings while navigating through application.
 
 After each start of OpenSpeedMonitor application, measurements are disabled generally. So even if you set up measurements as described in previous section none of your measurement jobs will start any measurements at all. You will have to activate measurements once, initially on job list view (requires login with admin rights).
 
@@ -85,7 +85,7 @@ Measurement data to show in diagrams can be chosen by three categories which are
 
 * _Aggregation and timeframe_
 
-    One can select the timeframe to be shown. Averages per timeframe can be build if necessary.
+    One can select the timeframe to be shown. Averages per timeframe can be built if necessary.
 
 * _Filter jobs_
 
@@ -130,7 +130,7 @@ Detail Analysis
 
 ![OsmDetailAnalysis](https://github.com/IteraSpeed/OpenSpeedMonitor/wiki/images/osm_v4_detailanalysis.jpg)
 
-These sort of analysis can be of great benefit detecting thirdparty libraries that slow down your site!
+These sort of analysis can be of great benefit detecting third party libraries that slow down your site!
 
 OsmDetailAnalysis is open source and licensed under same licence as OpenSpeedMonitor.
 
@@ -171,7 +171,7 @@ Prerequisites
 
     Mainly tested with Apache Tomcat. Should run on most servlet containers. See [full list of supported Java EE containers][11] in grails documentation for further details.
 
-* [optional, but recommended] Relational data base managing system (DBMS).
+* [optional, but recommended] Relational database management system (DBMS).
 
     Tested with MySQL. Should run with Oracle out of the box.
 
@@ -241,9 +241,9 @@ Development
 =====================
 To contribute to the code base or develop your own features you should be familiar with [grails][3]. Groovy and Javascript skills would be an asset, too.
 
-OpenSpeedMonitor is a monolithic web application. Respective grails plugin structure several external plugins are integrated. Before publishing under [Apache License][12] we developed the tool under version control in an own git server. So older history can't be found on github.
+OpenSpeedMonitor is a monolithic web application. Respective grails plugin structure several external plugins are integrated. Before publishing under [Apache License][12] we developed the tool under version control in an own git server. So older history can't be found on GitHub.
 
-As IDE you can use [Groovy/Grails Tool Suite][16] from SpringSource, which is an eclipse bundle optimized for groovy and grails development. IntelliJIdea has excellent groovy/grails support within its ultimate edition.
+As IDE you can use [Groovy/Grails Tool Suite][16] from SpringSource, which is an eclipse bundle optimized for groovy and grails development. IntelliJ Idea has excellent groovy/grails support within its ultimate edition.
 
 Although it works with an H2 in memory database out of the box it's highly recommended to develop and test with a relational database server like MySQL.
 


### PR DESCRIPTION
I fixed a few spelling mistakes that existed in README.md

There are still some inconsistencies you should decide on though, such as whether to capitalise acronyms or not. For example, API and api both exist in the content.