### PR TITLE
fix wptStatus set to waiting in migration script

### DIFF
--- a/grails-app/migrations/2018-10-11-v500-job-result-status.groovy
+++ b/grails-app/migrations/2018-10-11-v500-job-result-status.groovy
@@ -191,14 +191,6 @@ databaseChangeLog = {
         ''')
     }
 
-    changeSet(author: "pal", id: "Task-5_update_wpt_status") {
-        sql('''
-            UPDATE job_result
-            SET wpt_status = 'WAITING'
-            WHERE wpt_status = 'PENDING';
-        ''')
-    }
-
     changeSet(author: "pal", id: "Task-6_update_description_type") {
         sql('''
             ALTER TABLE job_result


### PR DESCRIPTION
Fixed a bug in migration, which set wptStatus to waiting from pending. However there is only pending in the enum so waiting causes an exception. Reverted the change.