### PR TITLE
Remove deprecated CSV export on time series, small fixes

### DIFF
--- a/docker/templates/osm-config.yml.j2
+++ b/docker/templates/osm-config.yml.j2
@@ -33,7 +33,6 @@ environments:
       username: '{{ default .Env.MYSQL_USER "osm" }}'
       password: '{{ default .Env.MYSQL_PASSWORD "osm123" }}'
       dbCreate: "managed by liquibase"
-      driverClassName: "com.mysql.jdbc.Driver"
       pooled: true
       properties:
         minEvictableIdleTimeMillis: 60000

--- a/grails-app/services/de/iteratec/osm/measurement/schedule/JobRunService.groovy
+++ b/grails-app/services/de/iteratec/osm/measurement/schedule/JobRunService.groovy
@@ -164,6 +164,7 @@ class JobRunService {
             }
         }
         log.debug("Cleanup done.")
+        return jobResultsToDelete.size()
     }
 
     private int rescheduleJobRunsYoungerThan(Date date) {

--- a/grails-app/views/eventResultDashboard/showAll.gsp
+++ b/grails-app/views/eventResultDashboard/showAll.gsp
@@ -148,9 +148,6 @@
                 </g:else>
             </ul>
         </div>
-        <g:actionSubmit value="${message(code: 'de.iteratec.ism.ui.labels.download.csv', 'default': 'Export as CSV')}"
-                        action="downloadCsv" class="btn btn-primary pull-right space-right show-button"/>
-
 
         <g:render template="/_resultSelection/hiddenWarnings"/>
         <!-- Actual tabs -->


### PR DESCRIPTION
* Removed the deprecated and unusable CSV export from the event result time series dashboard (The CSI time series still uses it for other reasons)
* The explicit `driverClassName` was removed from the docker template, as suggested by a warning log by the driver
* Added a return a missing return value to a function that caused problems otherwise