### PR TITLE
Wrong threshold value for failed jobs

### DIFF
--- a/frontend/src/app/modules/landing/landing.component.html
+++ b/frontend/src/app/modules/landing/landing.component.html
@@ -38,8 +38,8 @@
         <p class="applicationName">{{ application }} </p>
         <ul class="clickable-list">
           <li *ngFor="let failingJob of failingJobs[application]"
-              [class.error]="failingJob.percentageFailLast5 >= 20"
-              [class.warning]="failingJob.percentageFailLast5 < 20">
+              [class.error]="failingJob.percentageFailLast5 >= 21"
+              [class.warning]="failingJob.percentageFailLast5 < 21">
             <a  href="/jobResult/listFailed?jobId={{failingJob.job_id}}">
               <aside class="percentage-aside">
                 <p class="percentage percentage-big">{{ failingJob.percentageFailLast5 }}%</p>

--- a/frontend/src/app/modules/landing/landing.component.html
+++ b/frontend/src/app/modules/landing/landing.component.html
@@ -38,8 +38,8 @@
         <p class="applicationName">{{ application }} </p>
         <ul class="clickable-list">
           <li *ngFor="let failingJob of failingJobs[application]"
-              [class.error]="failingJob.percentageFailLast5 >= 21"
-              [class.warning]="failingJob.percentageFailLast5 < 21">
+              [class.error]="failingJob.percentageFailLast5 > 20"
+              [class.warning]="failingJob.percentageFailLast5 <= 20">
             <a  href="/jobResult/listFailed?jobId={{failingJob.job_id}}">
               <aside class="percentage-aside">
                 <p class="percentage percentage-big">{{ failingJob.percentageFailLast5 }}%</p>

--- a/frontend/src/styles/clickable-list.scss
+++ b/frontend/src/styles/clickable-list.scss
@@ -95,6 +95,6 @@
   }
 
   li.warning:hover {
-    background: darken($color-error-light, 5);
+    background: darken($color-warning-light, 5);
   }
 }


### PR DESCRIPTION
Fixed: Landing page used to show jobs with a fail rate of 1-19% as warning but the correct value is 1-20%.
Fixed: wrong hover for warning elements