### PR TITLE
[IT-2549] always show chart switch navigation

### DIFF
--- a/grails-app/assets/javascripts/chartSwitch.js
+++ b/grails-app/assets/javascripts/chartSwitch.js
@@ -102,10 +102,7 @@ OpenSpeedMonitor.ChartModules.UrlHandling.ChartSwitch = (function () {
             if (updatedMap["measurand"] == null) updatedMap["measurand"] = "{\"values\":[\"" + measurand + "\"]}";
         }
         var params = $.param(updatedMap, true);
-        var showLinks = false;
-        if (params.length > 0) {
-            showLinks = true;
-        }
+        var showLinks = true;
         updateUrl("#timeSeriesWithDataLink", OpenSpeedMonitor.urls.eventResultDashboardShowAll + "?" + params, showLinks);
         updateUrl("#pageAggregationWithDataLink", OpenSpeedMonitor.urls.pageAggregationShow + "?" + params, showLinks);
         updateUrl("#jobGroupAggregationWithDataLink", OpenSpeedMonitor.urls.jobGroupAggregationShow + "?" + params, showLinks);


### PR DESCRIPTION
The chart switch navigation was missing on some charts. There was an old check for params, which seemed unnecessary. This was removed, so the navigation will show on every chart again.