### PR TITLE
[IT-2559] fixed user delete

### DIFF
--- a/grails-app/views/_common/modals/_deleteDialog.gsp
+++ b/grails-app/views/_common/modals/_deleteDialog.gsp
@@ -18,7 +18,7 @@ This is the standard dialog that initiates the delete action.
             </div>
 
             <div class="modal-footer">
-                <g:form>
+                <g:form useToken="true">
                     <button class="btn btn-default" data-dismiss="modal" aria-hidden="true"><g:message code="default.button.cancel.label"
                                                                                            default="Cancel"/></button>
                     <g:hiddenField name="id" value="${item ? item.id : params.id}"/>


### PR DESCRIPTION
Because of a missing form token users couldn't be deleted. This will now be available for every crud delete.