### PR TITLE
[IT-2562] Enabled editing of user roles

### DIFF
--- a/grails-app/controllers/de/iteratec/osm/security/UserController.groovy
+++ b/grails-app/controllers/de/iteratec/osm/security/UserController.groovy
@@ -20,6 +20,18 @@ class UserController extends grails.plugin.springsecurity.ui.UserController {
     def show(User user) {
         respond user
     }
+
+    def edit() {
+        Map model = super.edit()
+        if (!model['roleMap']) {
+            List<Role> allRoles = Role.list()
+            allRoles.each { role ->
+                model['roleMap'].put(role, false)
+            }
+        }
+        return model
+    }
+
     def search(){
         params.action = "index"
         redirect(params)


### PR DESCRIPTION
- Edit method of the UserController was overwritten so that the 'roleMap' can be filled with all available roles if it is empty.