### PR TITLE
[IT-2577] Removed double header and unnecessary background

### DIFF
--- a/frontend/src/styles/layout.scss
+++ b/frontend/src/styles/layout.scss
@@ -1,7 +1,6 @@
 @import "colors";
 
 .content {
-  background-color: $color-background;
   padding: 20px;
 }
 

--- a/grails-app/views/connectivityProfile/list.gsp
+++ b/grails-app/views/connectivityProfile/list.gsp
@@ -3,7 +3,7 @@
 <html>
     <head>
         <meta name="layout" content="layoutOsm" />
-        <g:set var="entityName" value="${message(code: 'connectivityProfile.label', default: 'Connection')}" scope="request"/>
+        <g:set var="connectivityLabel" value="${message(code: 'connectivityProfile.label', default: 'Connection')}" scope="request"/>
         <title><g:message code="connectivityProfile.label.plural" /></title>
     </head>
 
@@ -12,7 +12,7 @@
         <div class="card">
             <div class="table-filter">
                 <a href="<g:createLink action="create" />" class="btn btn-primary pull-right">
-                    <i class="fas fa-plus"></i> <g:message code="default.create.label" args="[entityName]"/>
+                    <i class="fas fa-plus"></i> <g:message code="default.create.label" args="[connectivityLabel]"/>
                 </a>
             </div>
             <section id="list-connectivityProfile" class="first">


### PR DESCRIPTION
- Removed the double header on the connectivityProfile page.
- Removed background so the crud view looks normal again.