### PR TITLE
Fixed broken filter in job list

### DIFF
--- a/grails-app/assets/javascripts/job/jobListFilter.js
+++ b/grails-app/assets/javascripts/job/jobListFilter.js
@@ -197,7 +197,7 @@ OpenSpeedMonitor.jobListFilter = (function () {
     };
 
     var showOnlyFiltersMatchRow = function (row) {
-        var isMatch = !showOnlyCheckboxes.showOnlyActive.isChecked || row.find(".job_active").val() == "true";
+        var isMatch = !showOnlyCheckboxes.showOnlyActive.isChecked || !(row.find(".job_active").val() === "false");
         isMatch = isMatch && (!showOnlyCheckboxes.showOnlyHighlighted.isChecked || row.hasClass("highlight"));
         isMatch = isMatch && (!showOnlyCheckboxes.showOnlyChecked.isChecked || row.find(".jobCheckbox").prop("checked"));
         isMatch = isMatch && (!showOnlyCheckboxes.showOnlyRunning.isChecked || row.find(".running").length > 0);

--- a/grails-app/assets/javascripts/job/jobListFilter.js
+++ b/grails-app/assets/javascripts/job/jobListFilter.js
@@ -197,7 +197,7 @@ OpenSpeedMonitor.jobListFilter = (function () {
     };
 
     var showOnlyFiltersMatchRow = function (row) {
-        var isMatch = !showOnlyCheckboxes.showOnlyActive.isChecked || !(row.find(".job_active").val() === "false");
+        var isMatch = !showOnlyCheckboxes.showOnlyActive.isChecked || row.find(".job_active").val() === "true";
         isMatch = isMatch && (!showOnlyCheckboxes.showOnlyHighlighted.isChecked || row.hasClass("highlight"));
         isMatch = isMatch && (!showOnlyCheckboxes.showOnlyChecked.isChecked || row.find(".jobCheckbox").prop("checked"));
         isMatch = isMatch && (!showOnlyCheckboxes.showOnlyRunning.isChecked || row.find(".running").length > 0);

--- a/grails-app/assets/javascripts/timeago/future-only-timeago.js
+++ b/grails-app/assets/javascripts/timeago/future-only-timeago.js
@@ -1,50 +1,52 @@
-FutureOnlyTimeago = function() {
-	var nextExecutionServerUrl = '';
-	var timeouts = [];
-	
-	jQuery.timeago.settings.allowFuture = true;
-	
-	function futureHandler(cronExpression, elem, parentElem) {
-		delete FutureOnlyTimeago.timeouts[elem];
-		jQuery.ajax({
-			type: 'POST', 
-			url: FutureOnlyTimeago.nextExecutionServerUrl,
-			data: { value: cronExpression, noprepend: true },
-			success : function(newNextExecutionHtml) {
-				// replace past date with new template
-				$(parentElem).html(newNextExecutionHtml);
-				var newElem = $('abbr.timeago', parentElem);
-				makeFutureOnlyTimeago(newElem);
-			}
-		});
-	};
+FutureOnlyTimeago = function () {
+    var nextExecutionServerUrl = '';
+    var timeouts = [];
 
-	function makeFutureOnlyTimeago(elem) {
-		var fromNowInMs = $(elem).attr('data-date-diff-ms');
-		var cronExpression = $(elem).attr('data-cronstring');
-		var parentElem = $(elem).parent();
-		
-		if (cronExpression && fromNowInMs < 1000 * 60 * 60 * 24 * 7) {
-			var updateTimeout = setTimeout(futureHandler.bind(this, cronExpression, elem, parentElem), fromNowInMs);
-			FutureOnlyTimeago.timeouts[elem] = updateTimeout;
-			
-			// cut off second as PrettyCron can only handle Cron expressions where minutes are the smallest unit
-			//var prettyCronString = prettyCron.toString(cronExpression.substr(cronExpression.indexOf(' ') + 1));
-			//$(parentElem).append('(<abbr class="cronExpression">' + prettyCronString + '</abbr>)');
-		}
-		$(elem).timeago();
-	}
-	
-	// ${createLink(action: 'nextExecution')}
-	function initializeTimeagos(timeagos, nextExecutionServerUrl) {
-		this.nextExecutionServerUrl = nextExecutionServerUrl;
-		this.timeouts = [];
-		$.each(timeagos, function (index, elem) {
-			makeFutureOnlyTimeago(elem);
-		});
-	}
-	
-	return {
-		init: initializeTimeagos
-	}
+    jQuery.timeago.settings.allowFuture = true;
+
+    function futureHandler(cronExpression, elem, parentElem) {
+        delete FutureOnlyTimeago.timeouts[elem];
+        jQuery.ajax({
+            type: 'POST',
+            url: FutureOnlyTimeago.nextExecutionServerUrl,
+            data: {value: cronExpression, noprepend: true},
+            success: function (newNextExecutionHtml) {
+                // replace past date with new template
+                var active = $('input.job_active', parentElem);
+                $(parentElem).html(newNextExecutionHtml);
+                $(parentElem).append(active);
+                var newElem = $('abbr.timeago', parentElem);
+                makeFutureOnlyTimeago(newElem);
+            }
+        });
+    };
+
+    function makeFutureOnlyTimeago(elem) {
+        var fromNowInMs = $(elem).attr('data-date-diff-ms');
+        var cronExpression = $(elem).attr('data-cronstring');
+        var parentElem = $(elem).parent();
+
+        if (cronExpression && fromNowInMs < 1000 * 60 * 60 * 24 * 7) {
+            var updateTimeout = setTimeout(futureHandler.bind(this, cronExpression, elem, parentElem), fromNowInMs);
+            FutureOnlyTimeago.timeouts[elem] = updateTimeout;
+
+            // cut off second as PrettyCron can only handle Cron expressions where minutes are the smallest unit
+            //var prettyCronString = prettyCron.toString(cronExpression.substr(cronExpression.indexOf(' ') + 1));
+            //$(parentElem).append('(<abbr class="cronExpression">' + prettyCronString + '</abbr>)');
+        }
+        $(elem).timeago();
+    }
+
+    // ${createLink(action: 'nextExecution')}
+    function initializeTimeagos(timeagos, nextExecutionServerUrl) {
+        this.nextExecutionServerUrl = nextExecutionServerUrl;
+        this.timeouts = [];
+        $.each(timeagos, function (index, elem) {
+            makeFutureOnlyTimeago(elem);
+        });
+    }
+
+    return {
+        init: initializeTimeagos
+    }
 }();


### PR DESCRIPTION
The status of 'Active' of a job is stored as a hidden field in the HTML of the job list. When a job is executed, the next execution time is recalculated. This overwrites the hidden field. The filter that filters for active jobs will not find the jobs without this field. 

Solution: The hidden field is added again when the new execution time is set.