### PR TITLE
Feature/perf aspects via query builder

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1650,7 +1650,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -3619,7 +3619,7 @@
     },
     "engine.io-client": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
       "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
       "dev": true,
       "requires": {
@@ -9360,7 +9360,7 @@
     },
     "socket.io-parser": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "dev": true,
       "requires": {

--- a/frontend/src/app/models/perfomance-aspect.model.ts
+++ b/frontend/src/app/models/perfomance-aspect.model.ts
@@ -5,6 +5,7 @@ export interface PerformanceAspect {
   id: number
   pageId: number
   jobGroupId: number
+  browserId: number
   measurand: SelectableMeasurand
   performanceAspectType: string
 }

--- a/frontend/src/app/modules/application-dashboard/models/location.model.ts
+++ b/frontend/src/app/modules/application-dashboard/models/location.model.ts
@@ -1,0 +1,9 @@
+export interface BrowserDto {
+  id: number
+  name: string
+}
+export interface LocationDto {
+  id: Number
+  name: string
+  parent: BrowserDto
+}

--- a/grails-app/domain/de/iteratec/osm/result/PerformanceAspect.groovy
+++ b/grails-app/domain/de/iteratec/osm/result/PerformanceAspect.groovy
@@ -1,11 +1,13 @@
 package de.iteratec.osm.result
 
 import de.iteratec.osm.csi.Page
+import de.iteratec.osm.measurement.environment.Browser
 import de.iteratec.osm.measurement.schedule.JobGroup
 
 class PerformanceAspect {
     JobGroup jobGroup
     Page page
+    Browser browser
     PerformanceAspectType performanceAspectType
 
     String metricIdentifier
@@ -14,7 +16,7 @@ class PerformanceAspect {
     static transients = ['metric']
 
     static constraints = {
-        performanceAspectType(unique: ['jobGroup', 'page'])
+        performanceAspectType(unique: ['jobGroup', 'page', 'browser'])
     }
 
 

--- a/grails-app/migrations/2019-04-30-v512-browser-in-perf-aspect.groovy
+++ b/grails-app/migrations/2019-04-30-v512-browser-in-perf-aspect.groovy
@@ -1,0 +1,12 @@
+databaseChangeLog = {
+    changeSet(author: "nkuhn (generated)", id: "1556619486219-1") {
+        sql("delete from performance_aspect" )
+    }
+    changeSet(author: "nkuhn (generated)", id: "1556619486219-2") {
+        addColumn(tableName: "performance_aspect") {
+            column(name: "browser_id", type: "bigint") {
+                constraints(nullable: "false")
+            }
+        }
+    }
+}

--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -75,4 +75,5 @@ databaseChangeLog = {
     include file: '2018-11-19-v500-job-group-graphite-servers.groovy'
     include file: '2018-12-12-v500-nullable-job-result-label.groovy'
     include file: '2019-03-13-v511-add-performance-aspect.groovy'
+    include file: '2019-04-30-v512-browser-in-perf-aspect.groovy'
 }

--- a/grails-app/services/de/iteratec/osm/result/ApplicationDashboardService.groovy
+++ b/grails-app/services/de/iteratec/osm/result/ApplicationDashboardService.groovy
@@ -121,7 +121,12 @@ class ApplicationDashboardService {
         }
         PerformanceAspectType.values().each { PerformanceAspectType performanceAspectType ->
             if(!performanceAspects.collect{it.performanceAspectType}.contains(performanceAspectType)){
-                performanceAspects.add([id: null, pageId: page.id, jobGroupId: jobGroup.id, performanceAspectType: performanceAspectType, metricIdentifier: performanceAspectType.defaultMetric.toString()])
+                performanceAspects.add([
+                        id                   : null,
+                        pageId               : page.id,
+                        jobGroupId           : jobGroup.id,
+                        performanceAspectType: performanceAspectType,
+                        metricIdentifier     : performanceAspectType.defaultMetric.toString()])
             }
         }
         performanceAspects.each {

--- a/src/main/groovy/de/iteratec/osm/result/dao/query/AspectUtil.groovy
+++ b/src/main/groovy/de/iteratec/osm/result/dao/query/AspectUtil.groovy
@@ -1,0 +1,46 @@
+package de.iteratec.osm.result.dao.query
+
+
+import de.iteratec.osm.result.PerformanceAspect
+import de.iteratec.osm.result.PerformanceAspectType
+import de.iteratec.osm.result.SelectedMeasurand
+import de.iteratec.osm.result.dao.EventResultProjection
+import groovy.transform.EqualsAndHashCode
+/**
+ * @author nkuhn
+ */
+class AspectUtil {
+
+    List<Long> jobGroupIds = []
+    List<Long> pageIds = []
+    List<PerformanceAspectType> aspectTypes = []
+
+    void addMissingAspectMeasurands(List<SelectedMeasurand> measurands, Closure<Boolean> validFn) {
+        getAspects().each {PerformanceAspect aspect ->
+            SelectedMeasurand aspectMetric = aspect.getMetric()
+            if (!measurands.contains(aspectMetric) && validFn(aspectMetric)) {
+                measurands.add(aspectMetric)
+            }
+        }
+    }
+
+    List<PerformanceAspect> getAspects() {
+        if (jobGroupIds.size() == 0 || pageIds.size() == 0 || this.aspectTypes.size() == 0) return []
+        return PerformanceAspect.createCriteria().list {
+            'in'('jobGroup', this.jobGroupIds)
+            'in'('page', this.pageIds)
+            'in'('performanceAspectType', this.aspectTypes)
+        }
+    }
+
+    void appendAspectMetrics(List<EventResultProjection> metricsFromBuilder){
+
+    }
+
+}
+
+@EqualsAndHashCode
+class AspectMetric {
+    PerformanceAspectType aspectType
+    SelectedMeasurand measurand
+}

--- a/src/main/groovy/de/iteratec/osm/result/dao/query/AspectUtil.groovy
+++ b/src/main/groovy/de/iteratec/osm/result/dao/query/AspectUtil.groovy
@@ -38,9 +38,3 @@ class AspectUtil {
     }
 
 }
-
-@EqualsAndHashCode
-class AspectMetric {
-    PerformanceAspectType aspectType
-    SelectedMeasurand measurand
-}

--- a/src/main/groovy/de/iteratec/osm/result/dao/query/EventResultQueryExecutor.groovy
+++ b/src/main/groovy/de/iteratec/osm/result/dao/query/EventResultQueryExecutor.groovy
@@ -14,6 +14,7 @@ class EventResultQueryExecutor {
     private EventResultTrimmer trimmer
     List<SelectedMeasurand> selectedMeasurands
 
+
     void setUserTimings(List<SelectedMeasurand> selectedMeasurands) {
         this.selectedMeasurands = selectedMeasurands.findAll { it.selectedType.isUserTiming() }
     }

--- a/src/test/groovy/de/iteratec/osm/result/PerformanceAspectSpec.groovy
+++ b/src/test/groovy/de/iteratec/osm/result/PerformanceAspectSpec.groovy
@@ -1,15 +1,17 @@
 package de.iteratec.osm.result
 
 import de.iteratec.osm.csi.Page
+import de.iteratec.osm.measurement.environment.Browser
 import de.iteratec.osm.measurement.schedule.JobGroup
 import grails.buildtestdata.BuildDataTest
 import grails.buildtestdata.mixin.Build
 import spock.lang.Specification
 
-@Build([JobGroup, Page, PerformanceAspect])
+@Build([JobGroup, Page, PerformanceAspect, Browser])
 class PerformanceAspectSpec extends Specification implements BuildDataTest {
     Page page1, page2
     JobGroup jobGroup1, jobGroup2
+    Browser browser1, browser2
     SelectedMeasurand metric
 
     def setup() {
@@ -17,6 +19,8 @@ class PerformanceAspectSpec extends Specification implements BuildDataTest {
         jobGroup1 = JobGroup.build()
         page2 = Page.build()
         jobGroup2 = JobGroup.build()
+        browser1 = Browser.build()
+        browser2 = Browser.build()
         metric = new SelectedMeasurand(Measurand.DOC_COMPLETE_TIME.name(), CachedView.CACHED)
     }
 
@@ -29,21 +33,30 @@ class PerformanceAspectSpec extends Specification implements BuildDataTest {
         PerformanceAspect.build(
                 page: page1,
                 jobGroup: jobGroup1,
+                browser: browser1,
                 performanceAspectType: PerformanceAspectType.PAGE_CONSTRUCTION_STARTED,
                 metric: metric).save(flush: true)
 
         when: "a potential duplicate to the first aspect is created"
-        PerformanceAspect duplicateAspect = new PerformanceAspect(page: Page.findById(inputPageId), jobGroup: JobGroup.findById(inputJobGroupId), performanceAspectType: performanceAspectType, metric: metric)
+        PerformanceAspect duplicateAspect = new PerformanceAspect(
+                page: Page.findById(inputPageId),
+                jobGroup: JobGroup.findById(inputJobGroupId),
+                browser: Browser.findById(inputBrowserId),
+                performanceAspectType: performanceAspectType,
+                metric: metric)
 
         then: "its validation only fails if it is really a duplicate"
         duplicateAspect.validate() == valid
 
         where: "there are real duplicates and no real duplicates"
-        inputPageId | inputJobGroupId | performanceAspectType                           | valid
-        1           | 1               | PerformanceAspectType.PAGE_CONSTRUCTION_STARTED | false
-        2           | 1               | PerformanceAspectType.PAGE_CONSTRUCTION_STARTED | true
-        1           | 2               | PerformanceAspectType.PAGE_CONSTRUCTION_STARTED | true
-        1           | 1               | PerformanceAspectType.PAGE_SHOWS_USEFUL_CONTENT | true
+        inputPageId | inputJobGroupId | inputBrowserId | performanceAspectType                           || valid
+        1           | 1               | 1              | PerformanceAspectType.PAGE_CONSTRUCTION_STARTED || false
+        2           | 1               | 1              | PerformanceAspectType.PAGE_CONSTRUCTION_STARTED || true
+        1           | 2               | 1              | PerformanceAspectType.PAGE_CONSTRUCTION_STARTED || true
+        1           | 1               | 2              | PerformanceAspectType.PAGE_CONSTRUCTION_STARTED || true
+        2           | 1               | 2              | PerformanceAspectType.PAGE_CONSTRUCTION_STARTED || true
+        1           | 2               | 2              | PerformanceAspectType.PAGE_CONSTRUCTION_STARTED || true
+        1           | 1               | 1              | PerformanceAspectType.PAGE_SHOWS_USEFUL_CONTENT || true
     }
 
     void "ensure metric survives database"() {
@@ -51,6 +64,7 @@ class PerformanceAspectSpec extends Specification implements BuildDataTest {
         PerformanceAspect.build(
                 page: page1,
                 jobGroup: jobGroup1,
+                browser: browser1,
                 performanceAspectType: PerformanceAspectType.PAGE_CONSTRUCTION_STARTED,
                 metric: metric).save(flush: true)
 


### PR DESCRIPTION
I realized, that we will need one PerformanceAspect per Application, Page **and Browser** instead of just Application and Page. 
So this is just the addition of browser to PerformanceAspect and the adaption of angular modal dialog to handle aspects with browsers. Where this dialog just shows aspects for one arbitrary browser and saves them for all relevant browsers at once until we support different aspects for multiple browsers within one page.

Querying EventResult data for aspects I will put into another branch so PR don't get too large.