### PR TITLE
Metric FInder: Align filmstrips by highlighted metric [IT-2703]

### DIFF
--- a/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.html
+++ b/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.html
@@ -1,5 +1,8 @@
 <div class="filmstrips-wrapper">
   <div class="filmstrips">
-    <osm-filmstrip *ngFor="let testResult of results" [result]="testResult" [highlightedMetric]="highlightedMetric"></osm-filmstrip>
+    <osm-filmstrip *ngFor="let testResult of results; index as i"
+                   [result]="testResult" [highlightedMetric]="highlightedMetric" [offset]="offsets[i]">
+
+    </osm-filmstrip>
   </div>
 </div>

--- a/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.html
+++ b/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.html
@@ -1,0 +1,5 @@
+<div class="filmstrips-wrapper">
+  <div class="filmstrips">
+    <osm-filmstrip *ngFor="let testResult of results" [result]="testResult" [highlightedMetric]="highlightedMetric"></osm-filmstrip>
+  </div>
+</div>

--- a/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.html
+++ b/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.html
@@ -1,6 +1,7 @@
 <div class="filmstrips-wrapper">
-  <div class="filmstrips">
-    <osm-filmstrip *ngFor="let testResult of results; index as i"
+  <div class="filmstrips" #scrollContainer>
+    <osm-filmstrip *ngFor="let testResult of results; index as i; trackBy:identifyResult"
+                   (highlightLoad)="highlightLoaded($event)"
                    [result]="testResult" [highlightedMetric]="highlightedMetric" [offset]="offsets[i]">
 
     </osm-filmstrip>

--- a/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.scss
+++ b/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.scss
@@ -1,0 +1,9 @@
+.filmstrips {
+  overflow-x: auto;
+  background: black;
+  border-radius: 4px;
+}
+
+.filmstrips-wrapper {
+  position: relative;
+}

--- a/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.spec.ts
+++ b/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.spec.ts
@@ -1,6 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ComparableFilmstripsComponent } from './comparable-filmstrips.component';
+import {FilmstripComponent} from '../filmstrip/filmstrip.component';
+import {FilmstripService} from '../../services/filmstrip.service';
+import {FilmstripServiceMock} from '../../services/filmstrip.service.mock';
 
 describe('ComparableFilmstripsComponent', () => {
   let component: ComparableFilmstripsComponent;
@@ -8,7 +11,10 @@ describe('ComparableFilmstripsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ComparableFilmstripsComponent ]
+      declarations: [ ComparableFilmstripsComponent, FilmstripComponent ],
+      providers: [
+        {provide: FilmstripService, useClass: FilmstripServiceMock}
+      ]
     })
     .compileComponents();
   }));

--- a/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.spec.ts
+++ b/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ComparableFilmstripsComponent } from './comparable-filmstrips.component';
+
+describe('ComparableFilmstripsComponent', () => {
+  let component: ComparableFilmstripsComponent;
+  let fixture: ComponentFixture<ComparableFilmstripsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ComparableFilmstripsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ComparableFilmstripsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.ts
+++ b/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.ts
@@ -1,0 +1,22 @@
+import {Component, Input, OnChanges, SimpleChanges} from '@angular/core';
+import {TestResult} from '../../models/test-result';
+
+@Component({
+  selector: 'osm-comparable-filmstrips',
+  templateUrl: './comparable-filmstrips.component.html',
+  styleUrls: ['./comparable-filmstrips.component.scss']
+})
+export class ComparableFilmstripsComponent implements OnChanges{
+
+  @Input()
+  results: TestResult[];
+
+  @Input()
+  highlightedMetric: string;
+
+  constructor() { }
+
+  ngOnChanges(changes: SimpleChanges): void {
+  }
+
+}

--- a/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.ts
+++ b/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.ts
@@ -1,5 +1,6 @@
 import {Component, Input, OnChanges, SimpleChanges} from '@angular/core';
 import {TestResult} from '../../models/test-result';
+import {FilmstripService} from '../../services/filmstrip.service';
 
 @Component({
   selector: 'osm-comparable-filmstrips',
@@ -14,9 +15,18 @@ export class ComparableFilmstripsComponent implements OnChanges{
   @Input()
   highlightedMetric: string;
 
-  constructor() { }
+  offsets: number[] = [];
+
+  constructor(private filmstripService: FilmstripService) { }
 
   ngOnChanges(changes: SimpleChanges): void {
+    this.computeFilmstripAlignment();
+  }
+
+  computeFilmstripAlignment() {
+    const thumbnailTimes = this.results.map(result => this.filmstripService.getThumbnailTime(result.timings[this.highlightedMetric]));
+    const maxThumbnailTime = Math.max(...thumbnailTimes);
+    this.offsets = thumbnailTimes.map(thumbnailTime => maxThumbnailTime - thumbnailTime);
   }
 
 }

--- a/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.ts
+++ b/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnChanges, SimpleChanges} from '@angular/core';
+import {Component, ElementRef, Input, OnChanges, SimpleChanges, ViewChild} from '@angular/core';
 import {TestResult} from '../../models/test-result';
 import {FilmstripService} from '../../services/filmstrip.service';
 
@@ -15,12 +15,18 @@ export class ComparableFilmstripsComponent implements OnChanges{
   @Input()
   highlightedMetric: string;
 
+  @ViewChild('scrollContainer')
+  scrollContainer: ElementRef;
+
   offsets: number[] = [];
+
+  private maxThumbnailWidth: number;
 
   constructor(private filmstripService: FilmstripService) { }
 
   ngOnChanges(changes: SimpleChanges): void {
     this.computeFilmstripAlignment();
+    this.maxThumbnailWidth = 0;
   }
 
   computeFilmstripAlignment() {
@@ -29,4 +35,19 @@ export class ComparableFilmstripsComponent implements OnChanges{
     this.offsets = thumbnailTimes.map(thumbnailTime => maxThumbnailTime - thumbnailTime);
   }
 
+  identifyResult(index: number, result: TestResult) {
+    return result.id;
+  }
+
+  highlightLoaded(highlightedImage: HTMLElement) {
+    const thumbnailWidth = highlightedImage.offsetWidth;
+    if (thumbnailWidth <= this.maxThumbnailWidth) {
+      return;
+    }
+    this.maxThumbnailWidth = thumbnailWidth;
+    const scrollElement = this.scrollContainer.nativeElement;
+    if (scrollElement) {
+      scrollElement.scrollLeft = highlightedImage.offsetLeft - scrollElement.offsetWidth / 2 + thumbnailWidth / 2;
+    }
+  }
 }

--- a/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.ts
+++ b/frontend/src/app/modules/metric-finder/components/comparable-filmstrips/comparable-filmstrips.component.ts
@@ -1,5 +1,5 @@
 import {Component, ElementRef, Input, OnChanges, SimpleChanges, ViewChild} from '@angular/core';
-import {TestResult} from '../../models/test-result';
+import {TestResult} from '../../models/test-result.model';
 import {FilmstripService} from '../../services/filmstrip.service';
 
 @Component({

--- a/frontend/src/app/modules/metric-finder/components/filmstrip/filmstrip.component.html
+++ b/frontend/src/app/modules/metric-finder/components/filmstrip/filmstrip.component.html
@@ -7,7 +7,10 @@
        (mouseover)="positionTimings($event)"
   >
     <span class="time">{{formatTime(thumbnail.time, 1)}}</span>
-    <img [src]="thumbnail.imageUrl" />
+
+    <img *ngIf="thumbnail.isHighlighted" [src]="thumbnail.imageUrl" (load)="highlightLoaded($event)" />
+    <img *ngIf="!thumbnail.isHighlighted" [src]="thumbnail.imageUrl" />
+
     <ul class="timings" *ngIf="thumbnail.timings.length">
       <li *ngFor="let timing of thumbnail.timings">{{ formatTiming(timing) }}</li>
     </ul>

--- a/frontend/src/app/modules/metric-finder/components/filmstrip/filmstrip.component.html
+++ b/frontend/src/app/modules/metric-finder/components/filmstrip/filmstrip.component.html
@@ -2,7 +2,8 @@
   <div class="filmstrip-item"
        *ngFor="let thumbnail of filmStrip$ | async"
        [class.has-change]="thumbnail.hasChange || thumbnail.timings.length"
-       [class.highlighted]="thumbnail.isHighlighted"
+       [class.is-highlighted]="thumbnail.isHighlighted"
+       [class.is-offset]="thumbnail.isOffset"
        (mouseover)="positionTimings($event)"
   >
     <span class="time">{{formatTime(thumbnail.time, 1)}}</span>

--- a/frontend/src/app/modules/metric-finder/components/filmstrip/filmstrip.component.scss
+++ b/frontend/src/app/modules/metric-finder/components/filmstrip/filmstrip.component.scss
@@ -12,7 +12,7 @@
     filter: brightness(50%);
     transition: filter 0.2s ease;
   }
-  &.highlighted img, &:hover img {
+  &.is-highlighted img, &:hover img {
     filter: brightness(100%);
   }
   .time {
@@ -35,5 +35,9 @@
   }
   &:hover .timings {
     display: block;
+  }
+
+  &.is-offset {
+    visibility: hidden;
   }
 }

--- a/frontend/src/app/modules/metric-finder/components/filmstrip/filmstrip.component.scss
+++ b/frontend/src/app/modules/metric-finder/components/filmstrip/filmstrip.component.scss
@@ -19,9 +19,14 @@
     display: block;
     text-align: center;
     padding: 0 5px 5px 5px;
+    line-height: 1.2em;
   }
   &.has-change .time {
     font-weight: bold;
+  }
+  &.is-highlighted .time {
+    font-size: 1.2em;
+    line-height: 1em;
   }
 
   .timings {

--- a/frontend/src/app/modules/metric-finder/components/filmstrip/filmstrip.component.ts
+++ b/frontend/src/app/modules/metric-finder/components/filmstrip/filmstrip.component.ts
@@ -1,8 +1,8 @@
-import {Component, Input, OnChanges, SimpleChanges} from '@angular/core';
+import {Component, EventEmitter, Input, OnChanges, Output, SimpleChanges} from '@angular/core';
 import {FilmstripService} from '../../services/filmstrip.service';
 import {BehaviorSubject, Observable} from 'rxjs';
-import {distinctUntilChanged, filter, map} from 'rxjs/operators';
 import {TestResult} from '../../models/test-result.model';
+import {filter, map} from 'rxjs/operators';
 import {combineLatest} from 'rxjs/internal/observable/combineLatest';
 import {FilmstripView, Timing} from '../../models/filmstrip-view.model';
 import {TranslateService} from '@ngx-translate/core';
@@ -25,6 +25,9 @@ export class FilmstripComponent implements OnChanges {
 
   @Input()
   offset: number;
+
+  @Output()
+  highlightLoad = new EventEmitter<HTMLElement>();
 
   private result$ = new BehaviorSubject<TestResult>(null);
 
@@ -89,5 +92,9 @@ export class FilmstripComponent implements OnChanges {
       offsetLeft -= parent.scrollLeft;
     }
     return offsetLeft;
+  }
+
+  highlightLoaded(event: Event) {
+    this.highlightLoad.emit(event.target as HTMLElement);
   }
 }

--- a/frontend/src/app/modules/metric-finder/components/filmstrip/filmstrip.component.ts
+++ b/frontend/src/app/modules/metric-finder/components/filmstrip/filmstrip.component.ts
@@ -23,6 +23,9 @@ export class FilmstripComponent implements OnChanges {
   @Input()
   highlightedMetric: string;
 
+  @Input()
+  offset: number;
+
   private result$ = new BehaviorSubject<TestResult>(null);
 
   constructor(
@@ -35,16 +38,15 @@ export class FilmstripComponent implements OnChanges {
     ).pipe(
       map(([filmstrips, result]) => result ? filmstrips[result.id] : null),
       filter(filmstrip => !!filmstrip),
-      distinctUntilChanged(),
-      map(filmstrip => this.filmstripService.createFilmstripView(filmstrip, this.result.timings, this.highlightedMetric))
+      map(filmstrip => this.filmstripService.createFilmstripView(filmstrip, this.result.timings, this.highlightedMetric, this.offset))
     );
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['result'].currentValue !== changes['result'].previousValue) {
+    if (changes['result'] && changes['result'].currentValue !== changes['result'].previousValue) {
       this.filmstripService.loadFilmstripIfNecessary(this.result);
-      this.result$.next(this.result);
     }
+    this.result$.next(this.result);
   }
 
   formatTime(millisecs: number, precision: number): string {

--- a/frontend/src/app/modules/metric-finder/components/line-chart/line-chart.component.ts
+++ b/frontend/src/app/modules/metric-finder/components/line-chart/line-chart.component.ts
@@ -248,6 +248,9 @@ export class LineChartComponent implements AfterContentInit, OnChanges {
     const timestamp = date.getTime();
     const bisectResults = bisector((testResult: TestResult) => testResult.date).left;
     const resultIndex = bisectResults(this.results, date);
+    if (!this.results[resultIndex]) {
+      return null;
+    }
     if (resultIndex > 0 &&
       timestamp - this.results[resultIndex - 1].date.getTime() < this.results[resultIndex].date.getTime() - timestamp) {
       return this.results[resultIndex - 1];

--- a/frontend/src/app/modules/metric-finder/metric-finder.component.html
+++ b/frontend/src/app/modules/metric-finder/metric-finder.component.html
@@ -1,11 +1,8 @@
 
 <osm-line-chart [results]="testResults$ | async" [metric]="metric" (resultSelectionChange)="setSelectedResults($event)"></osm-line-chart>
 
-<div class="filmstrips-wrapper">
-  <div class="filmstrips">
-  <osm-filmstrip *ngFor="let testResult of selected" [result]="testResult" [highlightedMetric]="metric"></osm-filmstrip>
-  </div>
-</div>
+<osm-comparable-filmstrips [results]="selected" [highlightedMetric]="metric"></osm-comparable-filmstrips>
+
 Metric:
 <select [(ngModel)]="metric">
   <option [value]="'SPEED_INDEX'">Speed Index</option>

--- a/frontend/src/app/modules/metric-finder/metric-finder.component.scss
+++ b/frontend/src/app/modules/metric-finder/metric-finder.component.scss
@@ -1,9 +1,0 @@
-.filmstrips {
-  overflow-x: auto;
-  background: black;
-  border-radius: 4px;
-}
-
-.filmstrips-wrapper {
-  position: relative;
-}

--- a/frontend/src/app/modules/metric-finder/metric-finder.component.spec.ts
+++ b/frontend/src/app/modules/metric-finder/metric-finder.component.spec.ts
@@ -8,6 +8,7 @@ import {FormsModule} from '@angular/forms';
 import {FilmstripComponent} from './components/filmstrip/filmstrip.component';
 import {FilmstripService} from './services/filmstrip.service';
 import {FilmstripServiceMock} from './services/filmstrip.service.mock';
+import {ComparableFilmstripsComponent} from './components/comparable-filmstrips/comparable-filmstrips.component';
 
 describe('MetricFinderComponent', () => {
   let component: MetricFinderComponent;
@@ -15,7 +16,7 @@ describe('MetricFinderComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [MetricFinderComponent, FilmstripComponent, LineChartComponent],
+      declarations: [MetricFinderComponent, FilmstripComponent, LineChartComponent, ComparableFilmstripsComponent],
       imports: [FormsModule],
       providers: [{
           provide: MetricFinderService,

--- a/frontend/src/app/modules/metric-finder/metric-finder.component.ts
+++ b/frontend/src/app/modules/metric-finder/metric-finder.component.ts
@@ -19,6 +19,6 @@ export class MetricFinderComponent {
   }
 
   setSelectedResults(results: TestResult[]) {
-    this.selected = results.sort((a, b) => a.date.getTime() - b.date.getTime());
+    this.selected = [...results].sort((a, b) => a.date.getTime() - b.date.getTime());
   }
 }

--- a/frontend/src/app/modules/metric-finder/metric-finder.module.ts
+++ b/frontend/src/app/modules/metric-finder/metric-finder.module.ts
@@ -9,12 +9,14 @@ import {FilmstripComponent} from './components/filmstrip/filmstrip.component';
 import {FilmstripService} from './services/filmstrip.service';
 import {CommonModule} from '@angular/common';
 import {TranslateModule} from '@ngx-translate/core';
+import { ComparableFilmstripsComponent } from './components/comparable-filmstrips/comparable-filmstrips.component';
 
 @NgModule({
   declarations: [
     MetricFinderComponent,
     LineChartComponent,
-    FilmstripComponent
+    FilmstripComponent,
+    ComparableFilmstripsComponent
   ],
   imports: [
     RouterModule.forChild([{path: '', component: MetricFinderComponent}]),

--- a/frontend/src/app/modules/metric-finder/models/filmstrip-view.model.ts
+++ b/frontend/src/app/modules/metric-finder/models/filmstrip-view.model.ts
@@ -9,6 +9,7 @@ export interface FilmstripViewThumbnail {
   imageUrl: string;
   hasChange: boolean;
   isHighlighted: boolean;
+  isOffset: boolean;
   timings: Timing[];
 }
 

--- a/frontend/src/app/modules/metric-finder/services/filmstrip.service.mock.ts
+++ b/frontend/src/app/modules/metric-finder/services/filmstrip.service.mock.ts
@@ -9,4 +9,6 @@ export class FilmstripServiceMock {
   loadFilmstripIfNecessary(result: TestResult): void {}
 
   loadFilmstrip(result: TestResult): void { }
+
+  getThumbnailTime(time: number): number { return 0; }
 }

--- a/frontend/src/app/modules/metric-finder/services/filmstrip.service.spec.ts
+++ b/frontend/src/app/modules/metric-finder/services/filmstrip.service.spec.ts
@@ -77,13 +77,14 @@ describe('FilmstripService', () => {
 
   it('fill up filmstrip list with interval steps and thumbnails', () => {
     const timings = {speedIndex: 120, docComplete: 220};
-    const calculatedFilmstrip: Thumbnail[] = filmstripService.createFilmstripView(thumbnails, timings, 'speedIndex');
+    const calculatedFilmstrip: Thumbnail[] = filmstripService.createFilmstripView(thumbnails, timings, 'speedIndex', 100);
     const expectedFilmstrip = [
-      {time: 0, imageUrl: 'bild1', hasChange: true, isHighlighted: false, timings: []},
-      {time: 100, imageUrl: 'bild1', hasChange: false, isHighlighted: false, timings: []},
-      {time: 200, imageUrl: 'bild1', hasChange: false, isHighlighted: true, timings: [{metric: 'speedIndex', time: 120}]},
-      {time: 300, imageUrl: 'bild1', hasChange: false, isHighlighted: false, timings: [{metric: 'docComplete', time: 220}]},
-      {time: 400, imageUrl: 'bild2', hasChange: true, isHighlighted: false, timings: []}
+      {time: -100, imageUrl: 'bild1', hasChange: false, isHighlighted: false, timings: [], isOffset: true},
+      {time: 0, imageUrl: 'bild1', hasChange: false, isHighlighted: false, timings: [], isOffset: false},
+      {time: 100, imageUrl: 'bild1', hasChange: false, isHighlighted: false, timings: [], isOffset: false},
+      {time: 200, imageUrl: 'bild1', hasChange: false, isHighlighted: true, timings: [{metric: 'speedIndex', time: 120}], isOffset: false},
+      {time: 300, imageUrl: 'bild1', hasChange: false, isHighlighted: false, timings: [{metric: 'docComplete', time: 220}], isOffset: false},
+      {time: 400, imageUrl: 'bild2', hasChange: true, isHighlighted: false, timings: [], isOffset: false}
     ];
 
     expect(calculatedFilmstrip).toEqual(expectedFilmstrip);


### PR DESCRIPTION
* all filmstrips are aligned by the highlighted metric
* the container scrolls automatically to center the highlighted metrics when results/metrics change