### PR TITLE
FrontendWatcher and Gradle Typo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -304,14 +304,13 @@ clean.delete << file('grails-app/assets/javascripts/node_modules')
 clean.delete << file('grails-app/assets/javascripts/frontend')
 clean.delete << file('grails-app/assets/stylesheets/node_modules')
 clean.delete << file('grails-app/assets/stylesheets/frontend')
-clean.delete << file('grails-app/assets/other/fronted')
+clean.delete << file('grails-app/assets/other/frontend')
 clean.delete << file('node_modules')
 clean.delete << file('grails-app/assets/javascripts/bower_components')
 clean.delete << file('grails-app/assets/stylesheets/bower_components')
 // Cleans old npm directory inside .gradle as these are not needed anymore because the build directory is used
 clean.delete << file('.gradle/npm')
-
-
+clean.delete << file('frontend/dist')
 
 sourceSets {
     main {

--- a/grails-app/init/de/iteratec/osm/FrontendWatcher.groovy
+++ b/grails-app/init/de/iteratec/osm/FrontendWatcher.groovy
@@ -28,6 +28,10 @@ class FrontendWatcher {
         String nodeLocation = new File(nodeExecLocation).getParent()
 
         if (location && nodeLocation) {
+
+            String frontendDistFolder = Paths.get("${location}/frontend/dist")
+            new File(frontendDistFolder).mkdirs()
+
             Thread.start {
                 String nodeModulesBin = Paths.get("${location}", "frontend", "node_modules", ".bin").toString()
 


### PR DESCRIPTION
- Fixed a typo in the build.gradle.
- Added the frontend/dist directory to the clean task.
- Try to create the frontend/dist directory if not existent, so the FrontendWatcher will not add (and fail) creating a directory watcher on a non-existent directory. This should fix the bug that the FrontendWatcher sometimes doesn't update the assets and needs a restart.