### PR TITLE
[IT-2724] fix external pullrequests not working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,18 +27,6 @@ notifications:
 addons:
   chrome: stable
 
-# set deployment key
-before_install:
-  - >-
-    openssl aes-256-cbc
-    -K $encrypted_0e6b9eee7eaa_key
-    -iv $encrypted_0e6b9eee7eaa_iv
-    -in scripts/ci/github_deploy_key.enc
-    -out github_deploy_key -d
-  - chmod 600 github_deploy_key
-  - eval $(ssh-agent -s)
-  - ssh-add github_deploy_key
-
 # Install ChromeDriver
 install:
   - wget -N https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip -P ~/
@@ -98,7 +86,16 @@ jobs:
           git stash -u;
         on:
           branch: release
-after_deploy:
+after_deploy: # set deployment key
+  - >-
+    openssl aes-256-cbc 
+    -K $encrypted_0e6b9eee7eaa_key
+    -iv $encrypted_0e6b9eee7eaa_iv
+    -in scripts/ci/github_deploy_key.enc
+    -out github_deploy_key -d
+  - chmod 600 github_deploy_key
+  - eval $(ssh-agent -s)
+  - ssh-add github_deploy_key
   - test $TRAVIS_BRANCH = "release" && bash scripts/ci/building/merge_release_into_dev_and_master.sh;
 
 

--- a/scripts/ci/building/merge_release_into_dev_and_master.sh
+++ b/scripts/ci/building/merge_release_into_dev_and_master.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
 git fetch --all
+git remote set-url origin git@github.com:iteratec/OpenSpeedMonitor.git
+git remote -v
 git add .
 git commit -m "Committing package-lock.json and build.gradle of release"
 git push
 git checkout develop
 git merge release
-git push https://iteraspeed:$GITHUB_USER_TOKEN@github.com/iteratec/OpenSpeedMonitor.git
+git push
 git checkout master
 git merge release
-git push https://iteraspeed:$GITHUB_USER_TOKEN@github.com/iteratec/OpenSpeedMonitor.git
+git push


### PR DESCRIPTION
This fixes pull requests from users that don't belong to the iteratec org and uses the new deployment key for the process of merging release back into dev.