### PR TITLE
Bugfix: Get value for aspect when no measurand is selected

### DIFF
--- a/src/main/groovy/de/iteratec/osm/result/dao/EventResultQueryBuilder.groovy
+++ b/src/main/groovy/de/iteratec/osm/result/dao/EventResultQueryBuilder.groovy
@@ -167,6 +167,15 @@ class EventResultQueryBuilder {
 
     EventResultQueryBuilder withPerformanceAspects(List<PerformanceAspectType> aspectTypes) {
         this.aspectUtil.setAspectTypes(aspectTypes)
+
+        if (!measurandQueryExecutor.selectedMeasurands) {
+            measurandQueryExecutor.setMeasurands([])
+        }
+
+        if (!userTimingQueryExecutor.selectedMeasurands) {
+            userTimingQueryExecutor.setUserTimings([])
+        }
+
         return this
     }
 


### PR DESCRIPTION
When the QueryBuilder was executed for an performance aspect and no measurand was passed, it resulted in a NullPointerException.