### PR TITLE
Hotfix/metric finder fixes

### DIFF
--- a/grails-app/domain/de/iteratec/osm/measurement/environment/Location.groovy
+++ b/grails-app/domain/de/iteratec/osm/measurement/environment/Location.groovy
@@ -77,7 +77,6 @@ class Location {
         queuethresholdgreenlimit(nullable: true, min: -2147483648, max: 2147483647)
         queuethresholdyellowlimit(nullable: true, min: -2147483648, max: 2147483647)
         queuethresholdredlimit(nullable: true, min: -2147483648, max: 2147483647)
-        wptServer(nullable: false)
     }
 
     /**

--- a/src/main/groovy/de/iteratec/osm/result/dao/EventResultQueryBuilder.groovy
+++ b/src/main/groovy/de/iteratec/osm/result/dao/EventResultQueryBuilder.groovy
@@ -2,12 +2,7 @@ package de.iteratec.osm.result.dao
 
 import de.iteratec.osm.csi.Page
 import de.iteratec.osm.measurement.schedule.JobGroup
-import de.iteratec.osm.result.CachedView
-import de.iteratec.osm.result.DeviceType
-import de.iteratec.osm.result.MeasurandGroup
-import de.iteratec.osm.result.OperatingSystem
-import de.iteratec.osm.result.PerformanceAspectType
-import de.iteratec.osm.result.SelectedMeasurand
+import de.iteratec.osm.result.*
 import de.iteratec.osm.result.dao.query.*
 import de.iteratec.osm.result.dao.query.projector.MeasurandAverageDataProjector
 import de.iteratec.osm.result.dao.query.projector.MeasurandRawDataProjector
@@ -88,6 +83,7 @@ class EventResultQueryBuilder {
                 return []
             case MetaDataSet.ASPECT:
                 return [
+                        new ProjectionProperty(dbName: 'id', alias: 'id'),
                         new ProjectionProperty(dbName: 'jobGroup.id', alias: 'jobGroupId'),
                         new ProjectionProperty(dbName: 'page.id', alias: 'pageId'),
                         new ProjectionProperty(dbName: 'browser.id', alias: 'browserId')

--- a/src/test/groovy/de/iteratec/osm/measurement/environment/BrowserServiceSpec.groovy
+++ b/src/test/groovy/de/iteratec/osm/measurement/environment/BrowserServiceSpec.groovy
@@ -28,12 +28,8 @@ import spock.lang.Unroll
 /**
  * Test-suite for {@link BrowserService}.
  */
-@Build([Browser, Location])
+@Build([Browser, Location, WebPageTestServer])
 class BrowserServiceSpec extends Specification implements BuildDataTest, ServiceUnitTest<BrowserService> {
-
-    void setupSpec() {
-        mockDomains(Browser, BrowserAlias)
-    }
 
     void "find by name or alias returns correct browsers"(String nameOrAlias, String expectedBrowserName) {
         given: "Two browsers with aliases"
@@ -89,9 +85,10 @@ class BrowserServiceSpec extends Specification implements BuildDataTest, Service
     void "Get extended Browser informations for Browser #browserName"() {
         given: "A browser with an associated Location with information"
         Browser b = Browser.build(name: "Chrome")
-        Location loc = Location.build(browser: b, active: true, operatingSystem: os, deviceType: dt)
-        loc.active = true
-        loc.save(flush: true)
+        new Location(
+                browser: b, active: true, operatingSystem: os, deviceType: dt,
+                label: 'loc', wptServer: WebPageTestServer.build(), location: 'loc'
+        ).save()
 
         when: "Getting Browser infos and look up for the created browser"
         List<BrowserInfoDto> browserInfos = service.getBrowserInfos()


### PR DESCRIPTION
Calculate aggregations of Performance Aspects correctly if the metric configured for the aspect is a user/hero timing.