### PR TITLE
refactored inefficient service access

### DIFF
--- a/grails-app/controllers/de/iteratec/osm/result/TabularResultPresentationController.groovy
+++ b/grails-app/controllers/de/iteratec/osm/result/TabularResultPresentationController.groovy
@@ -381,18 +381,30 @@ class TabularResultPresentationController {
             }
         }
 
+        final DateTimeFormatter FORMATTER = csvExportService.CSV_TABLE_DATE_TIME_FORMAT;
         // round doubles and convert date
         result.each { row ->
             // jobResultDate
-            row[0] = csvExportService.CSV_TABLE_DATE_TIME_FORMAT.print(new DateTime(row[0]))
+            row[0] = FORMATTER.print(new DateTime(row[0]))
             // csByWptDocCompleteInPercent
             row[8] = row[8]?.round(2).toString()
             // csByWptVisuallyCompleteInPercent
             row[23] = row[23]?.round(2).toString()
             // get wptUrl
-            row[32] = csvExportService.buildTestDetailsURL(row[32], row[19], row[24])
+            row[32] = buildTestDetailsURL(row[32], row[19], row[24])
         }
         return result
+    }
+
+    private final String buildTestDetailsURL(final JobResult jobResult, final Integer numberOfWptRun, final Integer oneBasedStepIndexInJourney) {
+        if (!jobResult) return "no_job_result_available"
+
+        final String baseUrl = jobResult.wptServerBaseurl?.toString()
+        final String testId = jobResult.testId?.toString()
+        final String wptRun = numberOfWptRun.toString()
+        final String step = oneBasedStepIndexInJourney.toString()
+
+        return "${baseUrl}result/${testId}/${wptRun}/details/#waterfall_view_step${step}"
     }
 
     private List<String> getCsvHeaders() {

--- a/grails-app/controllers/de/iteratec/osm/result/TabularResultPresentationController.groovy
+++ b/grails-app/controllers/de/iteratec/osm/result/TabularResultPresentationController.groovy
@@ -34,6 +34,7 @@ import de.iteratec.osm.util.CsvExportService
 import org.hibernate.sql.JoinType
 import org.joda.time.DateTime
 import org.joda.time.Interval
+import org.joda.time.format.DateTimeFormat
 import org.joda.time.format.DateTimeFormatter
 import org.joda.time.format.ISODateTimeFormat
 
@@ -48,6 +49,10 @@ import org.joda.time.format.ISODateTimeFormat
 class TabularResultPresentationController {
 
     private final static String JAVASCRIPT_DATE_FORMAT_STRING = 'dd.mm.yyyy'
+    /**
+     * The {@link org.joda.time.format.DateTimeFormat} used for CSV export and table view.
+     */
+    private static final DateTimeFormatter CSV_TABLE_DATE_TIME_FORMAT = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss")
 
     JobGroupService jobGroupService
     BrowserService browserService
@@ -381,11 +386,11 @@ class TabularResultPresentationController {
             }
         }
 
-        final DateTimeFormatter FORMATTER = csvExportService.CSV_TABLE_DATE_TIME_FORMAT;
+
         // round doubles and convert date
         result.each { row ->
             // jobResultDate
-            row[0] = FORMATTER.print(new DateTime(row[0]))
+            row[0] = CSV_TABLE_DATE_TIME_FORMAT.print(new DateTime(row[0]))
             // csByWptDocCompleteInPercent
             row[8] = row[8]?.round(2).toString()
             // csByWptVisuallyCompleteInPercent

--- a/grails-app/services/de/iteratec/osm/util/CsvExportService.groovy
+++ b/grails-app/services/de/iteratec/osm/util/CsvExportService.groovy
@@ -15,22 +15,7 @@ class CsvExportService {
      * The {@link org.joda.time.format.DateTimeFormat} used for CSV export and table view.
      */
     static final DateTimeFormatter CSV_TABLE_DATE_TIME_FORMAT = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss")
-
-
-    String buildTestDetailsURL(JobResult jobResult, Integer numberOfWptRun, Integer oneBasedStepIndexInJourney) {
-        String urlString = "no_job_result_available"
-
-        if (jobResult) {
-            String baseUrl = jobResult?.wptServerBaseurl?.toString()
-            String testId = jobResult?.testId?.toString()
-            String wptRun = numberOfWptRun.toString()
-            String step = oneBasedStepIndexInJourney.toString()
-
-            urlString = "${baseUrl}result/${testId}/${wptRun}/details/#waterfall_view_step${step}"
-        }
-
-        return urlString
-    }
+    
 
     /**
      * Writes given data as csv file to target.

--- a/grails-app/services/de/iteratec/osm/util/CsvExportService.groovy
+++ b/grails-app/services/de/iteratec/osm/util/CsvExportService.groovy
@@ -1,21 +1,12 @@
 package de.iteratec.osm.util
 
-import de.iteratec.osm.result.JobResult
 import grails.gorm.transactions.Transactional
-import org.joda.time.format.DateTimeFormat
-import org.joda.time.format.DateTimeFormatter
 import org.supercsv.encoder.DefaultCsvEncoder
 import org.supercsv.io.CsvListWriter
 import org.supercsv.prefs.CsvPreference
 
 @Transactional
 class CsvExportService {
-
-    /**
-     * The {@link org.joda.time.format.DateTimeFormat} used for CSV export and table view.
-     */
-    static final DateTimeFormatter CSV_TABLE_DATE_TIME_FORMAT = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss")
-    
 
     /**
      * Writes given data as csv file to target.


### PR DESCRIPTION
locally reduced csv export for test dataset from 65s to 5s; additional evaluation after roll-out required to check performance impact in live environment