### PR TITLE
Undo changes in original Aggregation JS files

### DIFF
--- a/grails-app/assets/javascripts/aggregation/aggregationChart.js
+++ b/grails-app/assets/javascripts/aggregation/aggregationChart.js
@@ -22,7 +22,6 @@ OpenSpeedMonitor.ChartModules.Aggregation = (function (selector) {
     var chartBarScoreComponent = OpenSpeedMonitor.ChartComponents.ChartBarScore();
     var chartSideLabelsComponent = OpenSpeedMonitor.ChartComponents.ChartSideLabels();
     var chartHeaderComponent = OpenSpeedMonitor.ChartComponents.ChartHeader();
-    // var data;
     var data = OpenSpeedMonitor.ChartModules.AggregationData(svg);
     var transitionDuration = OpenSpeedMonitor.ChartComponents.common.transitionDuration;
 
@@ -39,9 +38,7 @@ OpenSpeedMonitor.ChartModules.Aggregation = (function (selector) {
     };
 
     var setData = function (inputData) {
-         //data.setData(inputData);
-        data = OpenSpeedMonitor.ChartModules.AggregationData;
-        OpenSpeedMonitor.ChartModules.AggregationData.setData(inputData);
+        data.setData(inputData);
         chartHeaderComponent.setData(data.getDataForHeader());
         chartBarScoreComponent.setData(data.getDataForBarScore());
         chartLegendComponent.setData(data.getDataForLegend());


### PR DESCRIPTION
- The original JavaScript files have been modified for testing purposes, but the changes have not been undone, so the original aggregation page does not work. For this reason the changes have been reversed.