### PR TITLE
Fix: Reset result selection

### DIFF
--- a/frontend/src/app/modules/result-selection/components/page-location-connectivity/selection-data/selection-data.component.ts
+++ b/frontend/src/app/modules/result-selection/components/page-location-connectivity/selection-data/selection-data.component.ts
@@ -85,6 +85,7 @@ export class SelectionDataComponent implements OnInit {
 
   private resetResultSelection() {
     if (this.parentSelection.length > 0) {
+      this.parentSelection$.next([]);
       this.parentSelection = [];
     }
     if (this.showChildSelection && this.childSelection.length > 0) {


### PR DESCRIPTION
If the result selection is reset, measured events and locations are now also reset.