### PR TITLE
Time series legend fix: Use ctrl key for Windows users

### DIFF
--- a/frontend/src/app/modules/time-series/services/line-chart.service.ts
+++ b/frontend/src/app/modules/time-series/services/line-chart.service.ts
@@ -523,7 +523,7 @@ export class LineChartService {
   }
 
   private onMouseClick(labelKey: string, incomingData: EventResultDataDTO): void {
-    if (d3Event.metaKey) {
+    if (d3Event.metaKey || d3Event.ctrlKey) {
       this.legendDataMap[labelKey].show ? this.legendDataMap[labelKey].show = false : this.legendDataMap[labelKey].show = true;
     } else {
       Object.keys(this.legendDataMap).forEach((legend) => {


### PR DESCRIPTION
For selecting multiple entries in time series chart legend, use control key for Windows users.