### PR TITLE
Search for job groups by id and not by name on CSI Benchmark chart

### DIFF
--- a/grails-app/controllers/de/iteratec/osm/csi/CsiBenchmarkController.groovy
+++ b/grails-app/controllers/de/iteratec/osm/csi/CsiBenchmarkController.groovy
@@ -53,7 +53,7 @@ class CsiBenchmarkController extends ExceptionHandlerController {
         }
 
         String selectedCsiType = params.csiType == "visuallyComplete" ? 'csByWptVisuallyCompleteInPercent' : 'csByWptDocCompleteInPercent'
-        List<JobGroup> allJobGroups = JobGroup.findAllByNameInList(cmd.jobGroups)
+        List<JobGroup> allJobGroups = JobGroup.findAllByIdInList(cmd.jobGroups)
 
         CsiAggregationInterval interval = CsiAggregationInterval.findByIntervalInMinutes(CsiAggregationInterval.DAILY)
 

--- a/grails-app/views/csiBenchmark/show.gsp
+++ b/grails-app/views/csiBenchmark/show.gsp
@@ -106,8 +106,8 @@
                 data: {
                     from: selectedTimeFrame[0].toISOString(),
                     to: selectedTimeFrame[1].toISOString(),
-                    selectedJobGroups: JSON.stringify($.map($("#folderSelectHtmlId option:selected"), function (e) {
-                        return $(e).text()
+                    jobGroups: JSON.stringify($.map($("#folderSelectHtmlId option:selected"), function (e) {
+                        return parseInt(e.value);
                     })),
                     csiType: $('input[name=csiTypeRadios]:checked').val()
                 },


### PR DESCRIPTION
This pull request fixes the bug which is reported in issue #289.
